### PR TITLE
v1.0.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------------------
+1.0.2
+* Change HTTParty version requirement to ~> 0.11, allowing HTTParty v0.14 (thanks @gaganawhad!)
+* Update Apache license headers.
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
 1.0.1
 * Relax HTTParty version requirement.
 * Add Apache license headers to source files.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 -------------------------------------------------------------------------------
 1.0.2
 * Change HTTParty version requirement to ~> 0.11, allowing HTTParty v0.14 (thanks @gaganawhad!)
+* Relax murmurhash3 and json-schema version requirements to ~> 0.1 and ~> 2.6, respectively (thanks @gaganawhad!)
 * Update Apache license headers.
 -------------------------------------------------------------------------------
 

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016-2017, Optimizely and contributors
+   Copyright 2016, Optimizely and contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016, Optimizely
+   Copyright 2016-2017, Optimizely and contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/bucketer.rb
+++ b/lib/optimizely/bucketer.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/bucketer.rb
+++ b/lib/optimizely/bucketer.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/condition.rb
+++ b/lib/optimizely/condition.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/condition.rb
+++ b/lib/optimizely/condition.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/error_handler.rb
+++ b/lib/optimizely/error_handler.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/error_handler.rb
+++ b/lib/optimizely/error_handler.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/event_builder.rb
+++ b/lib/optimizely/event_builder.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/event_builder.rb
+++ b/lib/optimizely/event_builder.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/event_dispatcher.rb
+++ b/lib/optimizely/event_dispatcher.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/event_dispatcher.rb
+++ b/lib/optimizely/event_dispatcher.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/exceptions.rb
+++ b/lib/optimizely/exceptions.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/exceptions.rb
+++ b/lib/optimizely/exceptions.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/helpers/group.rb
+++ b/lib/optimizely/helpers/group.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/helpers/group.rb
+++ b/lib/optimizely/helpers/group.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/helpers/validator.rb
+++ b/lib/optimizely/helpers/validator.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/helpers/validator.rb
+++ b/lib/optimizely/helpers/validator.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/logger.rb
+++ b/lib/optimizely/logger.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/logger.rb
+++ b/lib/optimizely/logger.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/params.rb
+++ b/lib/optimizely/params.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/params.rb
+++ b/lib/optimizely/params.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/project_config.rb
+++ b/lib/optimizely/project_config.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/project_config.rb
+++ b/lib/optimizely/project_config.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/version.rb
+++ b/lib/optimizely/version.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/version.rb
+++ b/lib/optimizely/version.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -14,5 +14,5 @@
 #    limitations under the License.
 #
 module Optimizely
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end

--- a/optimizely-sdk.gemspec
+++ b/optimizely-sdk.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 0.41.1"
 
   spec.add_runtime_dependency "murmurhash3", "~> 0.1.6"
-  spec.add_runtime_dependency "httparty", ">= 0.11.0", "< 0.14.0"
+  spec.add_runtime_dependency "httparty", "~> 0.11"
   spec.add_runtime_dependency "json-schema", "~> 2.6.2"
 end

--- a/optimizely-sdk.gemspec
+++ b/optimizely-sdk.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.4.0"
   spec.add_development_dependency "rubocop", "~> 0.41.1"
 
-  spec.add_runtime_dependency "murmurhash3", "~> 0.1.6"
+  spec.add_runtime_dependency "murmurhash3", "~> 0.1"
   spec.add_runtime_dependency "httparty", "~> 0.11"
-  spec.add_runtime_dependency "json-schema", "~> 2.6.2"
+  spec.add_runtime_dependency "json-schema", "~> 2.6"
 end

--- a/spec/audience_spec.rb
+++ b/spec/audience_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/audience_spec.rb
+++ b/spec/audience_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/benchmarking/benchmark.rb
+++ b/spec/benchmarking/benchmark.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/benchmarking/benchmark.rb
+++ b/spec/benchmarking/benchmark.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/benchmarking/data.rb
+++ b/spec/benchmarking/data.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/benchmarking/data.rb
+++ b/spec/benchmarking/data.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/bucketing_spec.rb
+++ b/spec/bucketing_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/bucketing_spec.rb
+++ b/spec/bucketing_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/condition_spec.rb
+++ b/spec/condition_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/condition_spec.rb
+++ b/spec/condition_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/event_builder_spec.rb
+++ b/spec/event_builder_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/event_builder_spec.rb
+++ b/spec/event_builder_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/event_dispatcher_spec.rb
+++ b/spec/event_dispatcher_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/event_dispatcher_spec.rb
+++ b/spec/event_dispatcher_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/project_config_spec.rb
+++ b/spec/project_config_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/project_config_spec.rb
+++ b/spec/project_config_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/spec_params.rb
+++ b/spec/spec_params.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/spec_params.rb
+++ b/spec/spec_params.rb
@@ -1,5 +1,5 @@
 #
-#    Copyright 2016, Optimizely
+#    Copyright 2016-2017, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.


### PR DESCRIPTION
**v1.0.2**
* Change HTTParty version requirement to ~> 0.11, allowing HTTParty v0.14 (thanks @gaganawhad!)
* Relax murmurhash3 and json-schema version requirements to ~> 0.1 and ~> 2.6, respectively (thanks @gaganawhad!)
* Update Apache license headers.