### PR TITLE
Clarifying ownership of SDK in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/optimizely/ruby-sdk/badge.svg)](https://coveralls.io/github/optimizely/ruby-sdk)
 [![Apache 2.0](https://img.shields.io/github/license/nebula-plugins/gradle-extra-configurations-plugin.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
-This repository houses the Ruby SDK for Optimizely's Full Stack product.
+This repository houses the official Ruby SDK for Optimizely Full Stack.
 
 ## Getting Started
 


### PR DESCRIPTION
Due to there being several third-party SDKs in different languages of varying quality / age, adding "official" to the phrasing of the title should help people understand that this is owned and maintained by Optimizely. Also removed "product" to better align with the other SDKs readme's.