### PR TITLE
Use parens to prevent string literal in condition

### DIFF
--- a/lib/optimizely/project_config.rb
+++ b/lib/optimizely/project_config.rb
@@ -87,7 +87,7 @@ module Optimizely
       @feature_flags = config.fetch('featureFlags', [])
       @groups = config.fetch('groups', [])
       @project_id = config['projectId']
-      @anonymize_ip = config.key? 'anonymizeIP' ? config['anonymizeIP'] : false
+      @anonymize_ip = config.key?('anonymizeIP') ? config['anonymizeIP'] : false
       @revision = config['revision']
       @rollouts = config.fetch('rollouts', [])
 


### PR DESCRIPTION
We just integrated this gem into our Rails project at work, and have begun seeing the following warning when booting the app (via docker) or running the suite:

`/usr/local/bundle/gems/optimizely-sdk-2.0.1/lib/optimizely/project_config.rb:90: warning: string literal in condition`

Our suspicion is that the ruby interpreter wasn't properly parsing the lack of parens on the `.key?` method call in: `@anonymize_ip = config.key? 'anonymizeIP' ? config['anonymizeIP'] : false` 

Lemme know what you think.  As I said, we just started using this gem but it's been working great so far - thanks for the work!