### PR TITLE
Renames notification-center methods

### DIFF
--- a/lib/optimizely/notification_center.rb
+++ b/lib/optimizely/notification_center.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2017, Optimizely and contributors
+#    Copyright 2017-2018, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -86,20 +86,31 @@ module Optimizely
       false
     end
 
+    # @deprecated Use {#clear_notification_listeners} instead.
     def clear_notifications(notification_type)
-      # Removes notifications for a certain notification type
-      #
-      # Args:
-      #  notification_type: one of the constants in NOTIFICATION_TYPES
+      @logger.log Logger::WARN, "'clear_notifications' is deprecated. Call 'clear_notification_listeners' instead."
+      clear_notification_listeners(notification_type)
+    end
 
+    # Removes notifications for a certain notification type
+    #
+    # @param notification_type - one of the constants in NOTIFICATION_TYPES
+
+    def clear_notification_listeners(notification_type)
       return nil unless notification_type_valid?(notification_type)
 
       @notifications[notification_type] = []
       @logger.log Logger::INFO, "All callbacks for notification type #{notification_type} have been removed."
     end
 
+    # @deprecated Use {#clear_all_notification_listeners} instead.
     def clean_all_notifications
-      # Removes all notifications
+      @logger.log Logger::WARN, "'clean_all_notifications' is deprecated. Call 'clear_all_notification_listeners' instead."
+      clear_all_notification_listeners
+    end
+
+    # Removes all notifications
+    def clear_all_notification_listeners
       @notifications.each_key { |key| @notifications[key] = [] }
     end
 

--- a/spec/notification_center_spec.rb
+++ b/spec/notification_center_spec.rb
@@ -255,7 +255,7 @@ describe Optimizely::NotificationCenter do
 
       it 'should not remove notifications for an invalid notification type' do
         invalid_type = 'Invalid notification'
-        expect { @inner_notification_center.clear_notifications(invalid_type) }
+        expect { @inner_notification_center.clear_notification_listeners(invalid_type) }
           .to raise_error(Optimizely::InvalidNotificationType)
         expect(spy_logger).to have_received(:log).once
                                                  .with(Logger::ERROR, 'Invalid notification type.')
@@ -273,7 +273,7 @@ describe Optimizely::NotificationCenter do
 
       it 'should remove all notifications for a valid notification type' do
         notification_type = Optimizely::NotificationCenter::NOTIFICATION_TYPES[:ACTIVATE]
-        @inner_notification_center.clear_notifications(notification_type)
+        @inner_notification_center.clear_notification_listeners(notification_type)
         expect(spy_logger).to have_received(:log).once
                                                  .with(Logger::INFO, "All callbacks for notification type #{notification_type} have been removed.")
         expect(
@@ -288,10 +288,19 @@ describe Optimizely::NotificationCenter do
         ).to eq(1)
       end
 
-      it 'should not throw an error when clear_notifications is called again for the same notification type' do
+      it 'should call clear_notification_listeners and log depreciation message' do
         notification_type = Optimizely::NotificationCenter::NOTIFICATION_TYPES[:ACTIVATE]
+        expect(@inner_notification_center).to receive(:clear_notification_listeners).once.with(notification_type)
         @inner_notification_center.clear_notifications(notification_type)
-        expect { @inner_notification_center.clear_notifications(notification_type) }
+        expect(spy_logger).to have_received(:log).once.with(
+          Logger::WARN, "'clear_notifications' is deprecated. Call 'clear_notification_listeners' instead."
+        )
+      end
+
+      it 'should not throw an error when clear_notification_listeners is called again for the same notification type' do
+        notification_type = Optimizely::NotificationCenter::NOTIFICATION_TYPES[:ACTIVATE]
+        @inner_notification_center.clear_notification_listeners(notification_type)
+        expect { @inner_notification_center.clear_notification_listeners(notification_type) }
           .to_not raise_error(Optimizely::InvalidNotificationType)
         expect(
           @inner_notification_center.notifications[
@@ -361,16 +370,24 @@ describe Optimizely::NotificationCenter do
       end
 
       it 'should remove all notifications for each notification type' do
-        @inner_notification_center.clean_all_notifications
+        @inner_notification_center.clear_all_notification_listeners
         @inner_notification_center.notifications.each_key do |key|
           expect(@inner_notification_center.notifications[key]).to be_empty
         end
       end
 
-      it 'clean_all_notifications does not throw an error when called again' do
-        @inner_notification_center.clean_all_notifications
-        expect { @inner_notification_center.clean_all_notifications }
+      it 'clear_all_notification_listeners does not throw an error when called again' do
+        @inner_notification_center.clear_all_notification_listeners
+        expect { @inner_notification_center.clear_all_notification_listeners }
           .to_not raise_error
+      end
+
+      it 'should call clear_all_notification_listeners and log depreciation message' do
+        expect(@inner_notification_center).to receive(:clear_all_notification_listeners).once
+        @inner_notification_center.clean_all_notifications
+        expect(spy_logger).to have_received(:log).once.with(
+          Logger::WARN, "'clean_all_notifications' is deprecated. Call 'clear_all_notification_listeners' instead."
+        )
       end
     end
 


### PR DESCRIPTION
- Renames 'clear_notifications' to 'clear_notification_listeners' and 'clean_all_notifications' to 'clear_all_notification_listeners'.
- Added deprecated methods along '@deprecated' meta tag.
- Added meta tags.