### PR TITLE
EventBuilder uses the same logger as Project

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -79,7 +79,7 @@ module Optimizely
       end
 
       @decision_service = DecisionService.new(@config, @user_profile_service)
-      @event_builder = EventBuilder.new(@config, logger)
+      @event_builder = EventBuilder.new(@config, @logger)
       @notification_center = NotificationCenter.new(@logger, @error_handler)
     end
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -459,6 +459,19 @@ describe 'Optimizely' do
       expect(project_instance.event_dispatcher).to have_received(:dispatch_event).with(Optimizely::Event.new(:post, conversion_log_url, params, post_headers)).once
     end
 
+    it 'should properly track an event with tags even when the project does not have a custom logger' do
+      project_instance = Optimizely::Project.new(config_body_JSON)
+
+      params = @expected_track_event_params
+      params[:visitors][0][:snapshots][0][:decisions][0][:variation_id] = '111129'
+      params[:visitors][0][:snapshots][0][:events][0][:tags] = {revenue: 42}
+
+      project_instance.config.set_forced_variation('test_experiment', 'test_user', 'variation')
+      allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
+      project_instance.track('test_event', 'test_user', nil, revenue: 42)
+      expect(project_instance.event_dispatcher).to have_received(:dispatch_event).with(Optimizely::Event.new(:post, conversion_log_url, params, post_headers)).once
+    end
+
     it 'should log a message if an exception has occurred during dispatching of the event' do
       allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(any_args).and_raise(RuntimeError)
       project_instance.track('test_event', 'test_user')


### PR DESCRIPTION
:wave: This recently caused a bit of noise for us 😅 after upgrading our SDK. It looks like `Optimizely::Project` is intended to work without a custom logger, but tracking events with tags started raising `NoMethodError`:

```
$GEM_HOME/optimizely-sdk-2.1.0/lib/optimizely/helpers/event_tag_utils.rb:52:in `get_revenue_value': undefined method `log' for nil:NilClass (NoMethodError)
    from $GEM_HOME/optimizely-sdk-2.1.0/lib/optimizely/event_builder.rb:220:in `block in get_conversion_params'
    from $GEM_HOME/optimizely-sdk-2.1.0/lib/optimizely/event_builder.rb:202:in `each'
    from $GEM_HOME/optimizely-sdk-2.1.0/lib/optimizely/event_builder.rb:202:in `get_conversion_params'
    from $GEM_HOME/optimizely-sdk-2.1.0/lib/optimizely/event_builder.rb:155:in `create_conversion_event'
    from $GEM_HOME/optimizely-sdk-2.1.0/lib/optimizely.rb:230:in `track'
```

---

- Previously, `EventBuilder` was instantiated by `Project` with the
  value of the `logger` local. However, when `Project` was not
  instantiated with a custom `logger`, `EventBuilder` would be
  instantiated with `nil` logger, which would cause `track` to raise a
  `NoMethodError` when called with tags.
- This commit changes the `Project` constructor to pass the `@logger`
  instance variable to `EventBuilder`, so that they are using the same
  logger, custom or otherwise.
- The added spec fails prior to the constructor change