### PR TITLE
Fix: Lint errors after rubocop update.

### DIFF
--- a/lib/optimizely/bucketer.rb
+++ b/lib/optimizely/bucketer.rb
@@ -92,9 +92,7 @@ module Optimizely
       end
 
       # Handle the case when the traffic range is empty due to sticky bucketing
-      if variation_id == ''
-        @config.logger.log(Logger::DEBUG, 'Bucketed into an empty traffic range. Returning nil.')
-      end
+      @config.logger.log(Logger::DEBUG, 'Bucketed into an empty traffic range. Returning nil.') if variation_id == ''
 
       @config.logger.log(Logger::INFO, "User '#{user_id}' is in no variation.")
       nil

--- a/lib/optimizely/bucketer.rb
+++ b/lib/optimizely/bucketer.rb
@@ -92,7 +92,12 @@ module Optimizely
       end
 
       # Handle the case when the traffic range is empty due to sticky bucketing
-      @config.logger.log(Logger::DEBUG, 'Bucketed into an empty traffic range. Returning nil.') if variation_id == ''
+      if variation_id == ''
+        @config.logger.log(
+          Logger::DEBUG,
+          'Bucketed into an empty traffic range. Returning nil.'
+        )
+      end
 
       @config.logger.log(Logger::INFO, "User '#{user_id}' is in no variation.")
       nil

--- a/lib/optimizely/helpers/validator.rb
+++ b/lib/optimizely/helpers/validator.rb
@@ -112,7 +112,9 @@ module Optimizely
           next if value.is_a?(String) && !value.empty?
 
           is_valid = false
-          logger.log(level, "#{Optimizely::Helpers::Constants::INPUT_VARIABLES[key.to_s.upcase]} is invalid") if logger_valid?(logger) && level
+          next unless logger_valid?(logger) && level
+
+          logger.log(level, "#{Optimizely::Helpers::Constants::INPUT_VARIABLES[key.to_s.upcase]} is invalid")
         end
         is_valid
       end

--- a/lib/optimizely/helpers/validator.rb
+++ b/lib/optimizely/helpers/validator.rb
@@ -112,9 +112,7 @@ module Optimizely
           next if value.is_a?(String) && !value.empty?
 
           is_valid = false
-          if logger_valid?(logger) && level
-            logger.log(level, "#{Optimizely::Helpers::Constants::INPUT_VARIABLES[key.to_s.upcase]} is invalid")
-          end
+          logger.log(level, "#{Optimizely::Helpers::Constants::INPUT_VARIABLES[key.to_s.upcase]} is invalid") if logger_valid?(logger) && level
         end
         is_valid
       end

--- a/lib/optimizely/project_config.rb
+++ b/lib/optimizely/project_config.rb
@@ -129,7 +129,9 @@ module Optimizely
           variation_id = variation['id']
           variation['featureEnabled'] = variation['featureEnabled'] == true
           variation_variables = variation['variables']
-          @variation_id_to_variable_usage_map[variation_id] = generate_key_map(variation_variables, 'id') unless variation_variables.nil?
+          next if variation_variables.nil?
+
+          @variation_id_to_variable_usage_map[variation_id] = generate_key_map(variation_variables, 'id')
         end
         @variation_id_map[key] = generate_key_map(variations, 'id')
         @variation_key_map[key] = generate_key_map(variations, 'key')

--- a/lib/optimizely/project_config.rb
+++ b/lib/optimizely/project_config.rb
@@ -129,9 +129,7 @@ module Optimizely
           variation_id = variation['id']
           variation['featureEnabled'] = variation['featureEnabled'] == true
           variation_variables = variation['variables']
-          unless variation_variables.nil?
-            @variation_id_to_variable_usage_map[variation_id] = generate_key_map(variation_variables, 'id')
-          end
+          @variation_id_to_variable_usage_map[variation_id] = generate_key_map(variation_variables, 'id') unless variation_variables.nil?
         end
         @variation_id_map[key] = generate_key_map(variations, 'id')
         @variation_key_map[key] = generate_key_map(variations, 'key')
@@ -357,9 +355,7 @@ module Optimizely
         return false
       end
 
-      unless @forced_variation_map.key? user_id
-        @forced_variation_map[user_id] = {}
-      end
+      @forced_variation_map[user_id] = {} unless @forced_variation_map.key? user_id
       @forced_variation_map[user_id][experiment_id] = variation_id
       @logger.log(Logger::DEBUG, "Set variation '#{variation_id}' for experiment '#{experiment_id}' and "\
                   "user '#{user_id}' in the forced variation map.")

--- a/optimizely-sdk.gemspec
+++ b/optimizely-sdk.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '~> 0.60.0'
   spec.add_development_dependency 'webmock'
 
   spec.add_runtime_dependency 'httparty', '~> 0.11'


### PR DESCRIPTION
**Summary**

- In PR https://github.com/optimizely/ruby-sdk/pull/133 Rubocop's latest version 0.60.0 was installed, due to which later PRs were getting failed with lint errors.
- Configured rubocop with latest version ` 0.60.0`.
- Fixed lint errors.