### PR TITLE
feat (audience match types): Update audience evaluator and project config for new audience match types.

### DIFF
--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -38,8 +38,7 @@ module Optimizely
       # Return true if there are no audiences
       return true if audience_ids.empty?
 
-      # Return false if there are audiences but no attributes
-      return false unless attributes
+      attributes ||= {}
 
       evaluate_condition_with_user_attributes = lambda do |condition|
         custom_attribute_condition_evaluator = CustomAttributeConditionEvaluator.new(attributes)
@@ -50,7 +49,7 @@ module Optimizely
       audience_ids.each do |audience_id|
         audience = config.get_audience_from_id(audience_id)
         audience_conditions = audience['conditions']
-        audience_conditions = JSON.parse(audience_conditions)
+        audience_conditions = JSON.parse(audience_conditions) if audience_conditions.is_a?(String)
         return true if ConditionTreeEvaluator.evaluate(audience_conditions, evaluate_condition_with_user_attributes)
       end
       false

--- a/lib/optimizely/custom_attribute_condition_evaluator.rb
+++ b/lib/optimizely/custom_attribute_condition_evaluator.rb
@@ -91,8 +91,6 @@ module Optimizely
       #                    2) the user attribute value is neither nil nor undefined
       #                 Returns false otherwise
 
-      return false unless @user_attributes
-
       !@user_attributes[condition['name']].nil?
     end
 

--- a/lib/optimizely/project_config.rb
+++ b/lib/optimizely/project_config.rb
@@ -31,6 +31,7 @@ module Optimizely
     attr_reader :account_id
     attr_reader :attributes
     attr_reader :audiences
+    attr_reader :typed_audiences
     attr_reader :events
     attr_reader :experiments
     attr_reader :feature_flags
@@ -79,6 +80,7 @@ module Optimizely
       @account_id = config['accountId']
       @attributes = config.fetch('attributes', [])
       @audiences = config.fetch('audiences', [])
+      @typed_audiences = config.fetch('typedAudiences', [])
       @events = config.fetch('events', [])
       @experiments = config['experiments']
       @feature_flags = config.fetch('featureFlags', [])
@@ -102,6 +104,7 @@ module Optimizely
       @experiment_key_map = generate_key_map(@experiments, 'key')
       @experiment_id_map = generate_key_map(@experiments, 'id')
       @audience_id_map = generate_key_map(@audiences, 'id')
+      @audience_id_map = @audience_id_map.merge(generate_key_map(@typed_audiences, 'id')) unless @typed_audiences.empty?
       @variation_id_map = {}
       @variation_key_map = {}
       @forced_variation_map = {}

--- a/spec/project_config_spec.rb
+++ b/spec/project_config_spec.rb
@@ -659,6 +659,26 @@ describe Optimizely::ProjectConfig do
       expect(project_config.rollout_id_map).to eq(expected_rollout_id_map)
       expect(project_config.rollout_experiment_id_map).to eq(expected_rollout_experiment_id_map)
     end
+
+    it 'should initialize properties correctly upon creating project with typed audience dict' do
+      project_config = Optimizely::ProjectConfig.new(JSON.dump(OptimizelySpec::CONFIG_DICT_WITH_TYPED_AUDIENCES), logger, error_handler)
+      config_body = OptimizelySpec::CONFIG_DICT_WITH_TYPED_AUDIENCES
+
+      expect(project_config.audiences).to eq(config_body['audiences'])
+
+      expected_audience_id_map = {
+        '0' => config_body['audiences'][7],
+        '3468206642' => config_body['audiences'][0],
+        '3988293898' => config_body['typedAudiences'][0],
+        '3988293899' => config_body['typedAudiences'][1],
+        '3468206646' => config_body['typedAudiences'][2],
+        '3468206647' => config_body['typedAudiences'][3],
+        '3468206644' => config_body['typedAudiences'][4],
+        '3468206643' => config_body['typedAudiences'][5]
+      }
+
+      expect(project_config.audience_id_map).to eq(expected_audience_id_map)
+    end
   end
 
   describe '@logger' do

--- a/spec/spec_params.rb
+++ b/spec/spec_params.rb
@@ -663,6 +663,391 @@ module OptimizelySpec
     }]
   }.freeze
 
+  CONFIG_DICT_WITH_TYPED_AUDIENCES = {
+    'version' => '4',
+    'rollouts' => [
+      {
+        'experiments' => [
+          {
+            'status' => 'Running',
+            'key' => '11488548027',
+            'layerId' => '11551226731',
+            'trafficAllocation' => [
+              {
+                'entityId' => '11557362669',
+                'endOfRange' => 10_000
+              }
+            ],
+            'audienceIds' => %w[3468206642 3988293898 3988293899 3468206646
+                                3468206647 3468206644 3468206643],
+            'variations' => [
+              {
+                'variables' => [],
+                'id' => '11557362669',
+                'key' => '11557362669',
+                'featureEnabled' => true
+              }
+            ],
+            'forcedVariations' => {},
+            'id' => '11488548027'
+          }
+        ],
+        'id' => '11551226731'
+      },
+      {
+        'experiments' => [
+          {
+            'status' => 'Paused',
+            'key' => '11630490911',
+            'layerId' => '11638870867',
+            'trafficAllocation' => [
+              {
+                'entityId' => '11475708558',
+                'endOfRange' => 0
+              }
+            ],
+            'audienceIds' => [],
+            'variations' => [
+              {
+                'variables' => [],
+                'id' => '11475708558',
+                'key' => '11475708558',
+                'featureEnabled' => false
+              }
+            ],
+            'forcedVariations' => {},
+            'id' => '11630490911'
+          }
+        ],
+        'id' => '11638870867'
+      },
+      {
+        'experiments' => [
+          {
+            'status' => 'Running',
+            'key' => '11488548028',
+            'layerId' => '11551226732',
+            'trafficAllocation' => [
+              {
+                'entityId' => '11557362670',
+                'endOfRange' => 10_000
+              }
+            ],
+            'audienceIds' => ['0'],
+            'audienceConditions' => ['and', %w[or 3468206642 3988293898], %w[or 3988293899 3468206646 3468206647 3468206644 3468206643]],
+            'variations' => [
+              {
+                'variables' => [],
+                'id' => '11557362670',
+                'key' => '11557362670',
+                'featureEnabled' => true
+              }
+            ],
+            'forcedVariations' => {},
+            'id' => '11488548028'
+          }
+        ],
+        'id' => '11551226732'
+      },
+      {
+        'experiments' => [
+          {
+            'status' => 'Paused',
+            'key' => '11630490912',
+            'layerId' => '11638870868',
+            'trafficAllocation' => [
+              {
+                'entityId' => '11475708559',
+                'endOfRange' => 0
+              }
+            ],
+            'audienceIds' => [],
+            'variations' => [
+              {
+                'variables' => [],
+                'id' => '11475708559',
+                'key' => '11475708559',
+                'featureEnabled' => false
+              }
+            ],
+            'forcedVariations' => {},
+            'id' => '11630490912'
+          }
+        ],
+        'id' => '11638870868'
+      }
+
+    ],
+    'anonymizeIP' => false,
+    'projectId' => '11624721371',
+    'variables' => [],
+    'featureFlags' => [
+      {
+        'experimentIds' => [],
+        'rolloutId' => '11551226731',
+        'variables' => [],
+        'id' => '11477755619',
+        'key' => 'feat'
+      },
+      {
+        'experimentIds' => [
+          '11564051718'
+        ],
+        'rolloutId' => '11638870867',
+        'variables' => [
+          {
+            'defaultValue' => 'x',
+            'type' => 'string',
+            'id' => '11535264366',
+            'key' => 'x'
+          }
+        ],
+        'id' => '11567102051',
+        'key' => 'feat_with_var'
+      },
+      {
+        'experimentIds' => [],
+        'rolloutId' => '11551226732',
+        'variables' => [],
+        'id' => '11567102052',
+        'key' => 'feat2'
+      },
+      {
+        'experimentIds' => ['1323241599'],
+        'rolloutId' => '11638870868',
+        'variables' => [
+          {
+            'defaultValue' => '10',
+            'type' => 'integer',
+            'id' => '11535264367',
+            'key' => 'z'
+          }
+        ],
+        'id' => '11567102053',
+        'key' => 'feat2_with_var'
+      }
+    ],
+    'experiments' => [
+      {
+        'status' => 'Running',
+        'key' => 'feat_with_var_test',
+        'layerId' => '11504144555',
+        'trafficAllocation' => [
+          {
+            'entityId' => '11617170975',
+            'endOfRange' => 10_000
+          }
+        ],
+        'audienceIds' => %w[3468206642 3988293898 3988293899 3468206646
+                            3468206647 3468206644 3468206643],
+        'variations' => [
+          {
+            'variables' => [
+              {
+                'id' => '11535264366',
+                'value' => 'xyz'
+              }
+            ],
+            'id' => '11617170975',
+            'key' => 'variation_2',
+            'featureEnabled' => true
+          }
+        ],
+        'forcedVariations' => {},
+        'id' => '11564051718'
+      },
+      {
+        'id' => '1323241597',
+        'key' => 'typed_audience_experiment',
+        'layerId' => '1630555627',
+        'status' => 'Running',
+        'variations' => [
+          {
+            'id' => '1423767503',
+            'key' => 'A',
+            'variables' => []
+          }
+        ],
+        'trafficAllocation' => [
+          {
+            'entityId' => '1423767503',
+            'endOfRange' => 10_000
+          }
+        ],
+        'audienceIds' => %w[3468206642 3988293898 3988293899 3468206646
+                            3468206647 3468206644 3468206643],
+        'forcedVariations' => {}
+      },
+      {
+        'id' => '1323241598',
+        'key' => 'audience_combinations_experiment',
+        'layerId' => '1323241598',
+        'status' => 'Running',
+        'variations' => [
+          {
+            'id' => '1423767504',
+            'key' => 'A',
+            'variables' => []
+          }
+        ],
+        'trafficAllocation' => [
+          {
+            'entityId' => '1423767504',
+            'endOfRange' => 10_000
+          }
+        ],
+        'audienceIds' => ['0'],
+        'audienceConditions' => ['and', %w[or 3468206642 3988293898], %w[or 3988293899 3468206646 3468206647 3468206644 3468206643]],
+        'forcedVariations' => {}
+      },
+      {
+        'id' => '1323241599',
+        'key' => 'feat2_with_var_test',
+        'layerId' => '1323241600',
+        'status' => 'Running',
+        'variations' => [
+          {
+            'variables' => [
+              {
+                'id' => '11535264367',
+                'value' => '150'
+              }
+            ],
+            'id' => '1423767505',
+            'key' => 'variation_2',
+            'featureEnabled' => true
+          }
+        ],
+        'trafficAllocation' => [
+          {
+            'entityId' => '1423767505',
+            'endOfRange' => 10_000
+          }
+        ],
+        'audienceIds' => ['0'],
+        'audienceConditions' => ['and', %w[or 3468206642 3988293898], %w[or 3988293899 3468206646 3468206647 3468206644 3468206643]],
+        'forcedVariations' => {}
+      }
+    ],
+    'audiences' => [
+      {
+        'id' => '3468206642',
+        'name' => 'exactString',
+        'conditions' => '["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "value": "Gryffindor"}]]]'
+      },
+      {
+        'id' => '3988293898',
+        'name' => '$$dummySubstringString',
+        'conditions' => '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+      },
+      {
+        'id' => '3988293899',
+        'name' => '$$dummyExists',
+        'conditions' => '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+      },
+      {
+        'id' => '3468206646',
+        'name' => '$$dummyExactNumber',
+        'conditions' => '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+      },
+      {
+        'id' => '3468206647',
+        'name' => '$$dummyGtNumber',
+        'conditions' => '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+      },
+      {
+        'id' => '3468206644',
+        'name' => '$$dummyLtNumber',
+        'conditions' => '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+      },
+      {
+        'id' => '3468206643',
+        'name' => '$$dummyExactBoolean',
+        'conditions' => '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+      },
+      {
+        'id' => '0',
+        'name' => '$$dummy',
+        'conditions' => '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+      }
+    ],
+    'typedAudiences' => [
+      {
+        'id' => '3988293898',
+        'name' => 'substringString',
+        'conditions' => '["and", ["or", ["or", '\
+  '{"name": "house", "type": "custom_attribute", "match":"substring", "value":"Slytherin"}]]]'
+      },
+      {
+        'id' => '3988293899',
+        'name' => 'exists',
+        'conditions' => '["and", ["or", ["or", {"name": "favorite_ice_cream", "type": "custom_attribute",'\
+  '"match":"exists"}]]]'
+      },
+      {
+        'id' => '3468206646',
+        'name' => 'exactNumber',
+        'conditions' => '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute",'\
+  '"match":"exact", "value": 45.5}]]]'
+      },
+      {
+        'id' => '3468206647',
+        'name' => 'gtNumber',
+        'conditions' => '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute",'\
+  '"match":"gt", "value": 70 }]]]'
+      },
+      {
+        'id' => '3468206644',
+        'name' => 'ltNumber',
+        'conditions' => '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute",'\
+  '"match":"lt", "value": 1.0 }]]]'
+      },
+      {
+        'id' => '3468206643',
+        'name' => 'exactBoolean',
+        'conditions' => '["and", ["or", ["or", {"name": "should_do_it", "type": "custom_attribute",'\
+  '"match":"exact", "value": true}]]]'
+      }
+    ],
+    'groups' => [],
+    'attributes' => [
+      {
+        'key' => 'house',
+        'id' => '594015'
+      },
+      {
+        'key' => 'lasers',
+        'id' => '594016'
+      },
+      {
+        'key' => 'should_do_it',
+        'id' => '594017'
+      },
+      {
+        'key' => 'favorite_ice_cream',
+        'id' => '594018'
+      }
+    ],
+    'botFiltering' => false,
+    'accountId' => '4879520872',
+    'events' => [
+      {
+        'key' => 'item_bought',
+        'id' => '594089',
+        'experimentIds' => %w[
+          11564051718
+          1323241597
+        ]
+      },
+      {
+        'key' => 'user_signed_up',
+        'id' => '594090',
+        'experimentIds' => %w[1323241598 1323241599]
+      }
+    ],
+    'revision' => '3'
+  }.freeze
+
   VALID_CONFIG_BODY_JSON = JSON.dump(VALID_CONFIG_BODY)
 
   INVALID_CONFIG_BODY = VALID_CONFIG_BODY.dup


### PR DESCRIPTION
### Summary

This updates project config and the audience evaluator to finish the implementation of typed audience evaluation:

- In audience_evaluator, allow evaluation to continue when no user attributes are passed (previously we were immediately returning `false` when no attributes were passed)
- Update project_config to update audience_id_map with typed_audiences
- Added unit tests checking that all top-level methods that accept user attributes can bucket users into experiments or rollouts that use typed audiences.

### Test Plan

New & existing unit tests
Ran compatibility suite tests for typed audiences