### PR TITLE
feat(audiences): Audience combinations

### DIFF
--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2018, Optimizely and contributors
+#    Copyright 2016-2019, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -31,7 +31,7 @@ module Optimizely
       # attributes - Hash representing user attributes which will be used in determining if
       #              the audience conditions are met.
       #
-      # Returns boolean representing if user satisfies audience conditions for any of the audiences or not.
+      # Returns boolean representing if user satisfies audience conditions for the audiences or not.
 
       audience_conditions = experiment['audienceConditions'] || experiment['audienceIds']
 
@@ -40,8 +40,9 @@ module Optimizely
 
       attributes ||= {}
 
+      custom_attr_condition_evaluator = CustomAttributeConditionEvaluator.new(attributes)
+
       evaluate_custom_attr = lambda do |condition|
-        custom_attr_condition_evaluator = CustomAttributeConditionEvaluator.new(attributes)
         return custom_attr_condition_evaluator.evaluate(condition)
       end
 

--- a/spec/audience_spec.rb
+++ b/spec/audience_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2018, Optimizely and contributors
+#    Copyright 2016-2017, 2019, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/audience_spec.rb
+++ b/spec/audience_spec.rb
@@ -21,54 +21,175 @@ describe Optimizely::Audience do
   before(:context) do
     @config_body = OptimizelySpec::VALID_CONFIG_BODY
     @config_body_json = OptimizelySpec::VALID_CONFIG_BODY_JSON
+    @config_typed_audience_json = JSON.dump(OptimizelySpec::CONFIG_DICT_WITH_TYPED_AUDIENCES)
   end
 
   before(:example) do
     @project_instance = Optimizely::Project.new(@config_body_json)
+    @project_typed_audience_instance = Optimizely::Project.new(@config_typed_audience_json)
   end
 
-  it 'should return true for user_in_experiment? if there are no audiences and no attributes' do
+  it 'should return true for user_in_experiment? when experiment is using no audience' do
+    user_attributes = {}
+    # Both Audience Ids and Conditions are Empty
     experiment = @project_instance.config.experiment_key_map['test_experiment']
+    experiment['audienceIds'] = []
+    experiment['audienceConditions'] = []
+
     expect(Optimizely::Audience.user_in_experiment?(@project_instance.config,
                                                     experiment,
-                                                    nil)).to be true
-  end
+                                                    user_attributes)).to be true
 
-  it 'should return true for user_in_experiment? if there are no audiences and there are attributes' do
+    # Audience Ids exist but Audience Conditions is Empty
     experiment = @project_instance.config.experiment_key_map['test_experiment']
-    user_attributes = {
-      'browser_type' => 'firefox'
-    }
+    experiment['audienceIds'] = ['11154']
+    experiment['audienceConditions'] = []
+
+    expect(Optimizely::Audience.user_in_experiment?(@project_instance.config,
+                                                    experiment,
+                                                    user_attributes)).to be true
+
+    # Audience Ids is Empty and  Audience Conditions is nil
+    experiment = @project_instance.config.experiment_key_map['test_experiment']
+    experiment['audienceIds'] = []
+    experiment['audienceConditions'] = nil
+
     expect(Optimizely::Audience.user_in_experiment?(@project_instance.config,
                                                     experiment,
                                                     user_attributes)).to be true
   end
 
-  it 'should return false for user_in_experiment? if there are audiences but no attributes' do
+  it 'should pass conditions when audience conditions exist else audienceIds are passed' do
+    user_attributes = {'test_attribute' => 'test_value_1'}
+    experiment = @project_instance.config.experiment_key_map['test_experiment']
+    experiment['audienceIds'] = ['11154']
+    allow(Optimizely::ConditionTreeEvaluator).to receive(:evaluate)
+
+    # Both Audience Ids and Conditions exist
+    experiment['audienceConditions'] = ['and', %w[or 3468206642 3988293898], %w[or 3988293899 3468206646 3468206647 3468206644 3468206643]]
+    Optimizely::Audience.user_in_experiment?(@project_instance.config,
+                                             experiment,
+                                             user_attributes)
+    expect(Optimizely::ConditionTreeEvaluator).to have_received(:evaluate).with(experiment['audienceConditions'], any_args).once
+
+    # Audience Ids exist but Audience Conditions is nil
+    experiment['audienceConditions'] = nil
+    Optimizely::Audience.user_in_experiment?(@project_instance.config,
+                                             experiment,
+                                             user_attributes)
+    expect(Optimizely::ConditionTreeEvaluator).to have_received(:evaluate).with(experiment['audienceIds'], any_args).once
+  end
+
+  it 'should return false for user_in_experiment? if there are audiences but nil or empty attributes' do
     experiment = @project_instance.config.experiment_key_map['test_experiment_with_audience']
+    allow(Optimizely::CustomAttributeConditionEvaluator).to receive(:new).and_call_original
+
+    # attributes set to empty dict
+    expect(Optimizely::Audience.user_in_experiment?(@project_instance.config,
+                                                    experiment,
+                                                    {})).to be false
+    # attributes set to nil
     expect(Optimizely::Audience.user_in_experiment?(@project_instance.config,
                                                     experiment,
                                                     nil)).to be false
+    expect(Optimizely::CustomAttributeConditionEvaluator).to have_received(:new).with({}).twice
   end
 
-  it 'should return true for user_in_experiment? if any one of the audience conditions are met' do
+  it 'should return true for user_in_experiment? when condition tree evaluator returns true' do
+    experiment = @project_instance.config.experiment_key_map['test_experiment']
     user_attributes = {
-      'browser_type' => 'firefox'
+      'test_attribute' => 'test_value_1'
     }
-
-    experiment = @project_instance.config.experiment_key_map['test_experiment_with_audience']
+    allow(Optimizely::ConditionTreeEvaluator).to receive(:evaluate).and_return(true)
     expect(Optimizely::Audience.user_in_experiment?(@project_instance.config,
                                                     experiment,
                                                     user_attributes)).to be true
   end
 
-  it 'should return false for user_in_experiment? if the audience conditions are not met' do
-    user_attributes = {
-      'browser_type' => 'chrome'
-    }
+  it 'should return false for user_in_experiment? when condition tree evaluator returns false or nil' do
     experiment = @project_instance.config.experiment_key_map['test_experiment_with_audience']
+    user_attributes = {
+      'browser_type' => 'firefox'
+    }
+
+    # condition tree evaluator returns nil
+    allow(Optimizely::ConditionTreeEvaluator).to receive(:evaluate).and_return(nil)
     expect(Optimizely::Audience.user_in_experiment?(@project_instance.config,
                                                     experiment,
                                                     user_attributes)).to be false
+
+    # condition tree evaluator returns false
+    allow(Optimizely::ConditionTreeEvaluator).to receive(:evaluate).and_return(false)
+    expect(Optimizely::Audience.user_in_experiment?(@project_instance.config,
+                                                    experiment,
+                                                    user_attributes)).to be false
+  end
+
+  it 'should correctly evaluate audience Ids and call custom attribute evaluator for leaf nodes' do
+    experiment = @project_instance.config.experiment_key_map['test_experiment_with_audience']
+    user_attributes = {
+      'browser_type' => 'firefox'
+    }
+    experiment['audienceIds'] = %w[11154 11155]
+    experiment['audienceConditions'] = nil
+
+    audience_11154 = @project_instance.config.get_audience_from_id('11154')
+    audience_11155 = @project_instance.config.get_audience_from_id('11155')
+    audience_11154_condition = JSON.parse(audience_11154['conditions'])[1][1][1]
+    audience_11155_condition = JSON.parse(audience_11155['conditions'])[1][1][1]
+
+    customer_attr = Optimizely::CustomAttributeConditionEvaluator.new(user_attributes)
+    allow(customer_attr).to receive(:exact_evaluator)
+    customer_attr.evaluate(audience_11154_condition)
+    customer_attr.evaluate(audience_11155_condition)
+
+    expect(customer_attr).to have_received(:exact_evaluator).with(audience_11154_condition).once
+    expect(customer_attr).to have_received(:exact_evaluator).with(audience_11155_condition).once
+  end
+
+  it 'should correctly evaluate audienceConditions and call custom attribute evaluator for leaf nodes' do
+    experiment = @project_typed_audience_instance.config.get_experiment_from_key('audience_combinations_experiment')
+    experiment['audienceIds'] = []
+    experiment['audienceConditions'] = ['or', %w[or 3468206642 3988293898], %w[or 3988293899 3468206646]]
+
+    audience_3468206642 = @project_typed_audience_instance.config.get_audience_from_id('3468206642')
+    audience_3988293898 = @project_typed_audience_instance.config.get_audience_from_id('3988293898')
+    audience_3988293899 = @project_typed_audience_instance.config.get_audience_from_id('3988293899')
+    audience_3468206646 = @project_typed_audience_instance.config.get_audience_from_id('3468206646')
+
+    audience_3468206642_condition = JSON.parse(audience_3468206642['conditions'])[1][1][1]
+    audience_3988293898_condition = audience_3988293898['conditions'][1][1][1]
+    audience_3988293899_condition = audience_3988293899['conditions'][1][1][1]
+    audience_3468206646_condition = audience_3468206646['conditions'][1][1][1]
+
+    customer_attr = Optimizely::CustomAttributeConditionEvaluator.new({})
+    allow(customer_attr).to receive(:exact_evaluator)
+    allow(customer_attr).to receive(:substring_evaluator)
+    allow(customer_attr).to receive(:exists_evaluator)
+    customer_attr.evaluate(audience_3468206642_condition)
+    customer_attr.evaluate(audience_3988293898_condition)
+    customer_attr.evaluate(audience_3988293899_condition)
+    customer_attr.evaluate(audience_3468206646_condition)
+
+    expect(customer_attr).to have_received(:exact_evaluator).with(audience_3468206642_condition).once
+    expect(customer_attr).to have_received(:substring_evaluator).with(audience_3988293898_condition).once
+    expect(customer_attr).to have_received(:exists_evaluator).with(audience_3988293899_condition).once
+    expect(customer_attr).to have_received(:exact_evaluator).with(audience_3468206646_condition).once
+  end
+
+  it 'should correctly evaluate leaf node in audienceConditions' do
+    experiment = @project_typed_audience_instance.config.get_experiment_from_key('audience_combinations_experiment')
+    experiment['audienceConditions'] = '3468206645'
+    customer_attr = Optimizely::CustomAttributeConditionEvaluator.new({})
+
+    audience_3468206645 = @project_typed_audience_instance.config.get_audience_from_id('3468206645')
+    audience_3468206645_condition1 = audience_3468206645['conditions'][1][1][1]
+    audience_3468206645_condition2 = audience_3468206645['conditions'][1][1][2]
+    allow(customer_attr).to receive(:exact_evaluator)
+    customer_attr.evaluate(audience_3468206645_condition1)
+    customer_attr.evaluate(audience_3468206645_condition2)
+
+    expect(customer_attr).to have_received(:exact_evaluator).with(audience_3468206645_condition1).once
+    expect(customer_attr).to have_received(:exact_evaluator).with(audience_3468206645_condition2).once
   end
 end

--- a/spec/audience_spec.rb
+++ b/spec/audience_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2017, Optimizely and contributors
+#    Copyright 2016-2018, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -92,6 +92,7 @@ describe Optimizely::Audience do
     expect(Optimizely::Audience.user_in_experiment?(@project_instance.config,
                                                     experiment,
                                                     nil)).to be false
+    # asserts nil attributes default to empty dict
     expect(Optimizely::CustomAttributeConditionEvaluator).to have_received(:new).with({}).twice
   end
 

--- a/spec/project_config_spec.rb
+++ b/spec/project_config_spec.rb
@@ -667,14 +667,15 @@ describe Optimizely::ProjectConfig do
       expect(project_config.audiences).to eq(config_body['audiences'])
 
       expected_audience_id_map = {
-        '0' => config_body['audiences'][7],
         '3468206642' => config_body['audiences'][0],
         '3988293898' => config_body['typedAudiences'][0],
         '3988293899' => config_body['typedAudiences'][1],
         '3468206646' => config_body['typedAudiences'][2],
         '3468206647' => config_body['typedAudiences'][3],
         '3468206644' => config_body['typedAudiences'][4],
-        '3468206643' => config_body['typedAudiences'][5]
+        '3468206643' => config_body['typedAudiences'][5],
+        '3468206645' => config_body['typedAudiences'][6],
+        '0' => config_body['audiences'][8]
       }
 
       expect(project_config.audience_id_map).to eq(expected_audience_id_map)

--- a/spec/project_config_spec.rb
+++ b/spec/project_config_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2018, Optimizely and contributors
+#    Copyright 2016-2019, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -370,8 +370,8 @@ describe 'Optimizely' do
 
       it 'should return nil when complex audience conditions do not match' do
         user_attributes = {'house' => 'Hufflepuff', 'lasers' => 45.5}
-        variation_to_return = @project_typed_audience_instance.config.get_variation_from_id('audience_combinations_experiment', '1423767504')
-        allow(@project_typed_audience_instance.decision_service.bucketer).to receive(:bucket).and_return(variation_to_return)
+        # variation_to_return = @project_typed_audience_instance.config.get_variation_from_id('audience_combinations_experiment', '1423767504')
+        allow(@project_typed_audience_instance.decision_service.bucketer).to receive(:bucket)
         allow(@project_typed_audience_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
 
         expect(@project_typed_audience_instance.activate('audience_combinations_experiment', 'test_user', user_attributes))
@@ -869,7 +869,8 @@ describe 'Optimizely' do
           }, {
             entity_id: Optimizely::Helpers::Constants::CONTROL_ATTRIBUTES['BOT_FILTERING'],
             key: Optimizely::Helpers::Constants::CONTROL_ATTRIBUTES['BOT_FILTERING'],
-            type: 'custom', value: false
+            type: 'custom',
+            value: false
           }
         ]
         params[:visitors][0][:snapshots][0][:decisions] = [

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2018, Optimizely and contributors
+#    Copyright 2016-2019, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/spec_params.rb
+++ b/spec/spec_params.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2018, Optimizely and contributors
+#    Copyright 2016-2019, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/spec_params.rb
+++ b/spec/spec_params.rb
@@ -678,8 +678,7 @@ module OptimizelySpec
                 'endOfRange' => 10_000
               }
             ],
-            'audienceIds' => %w[3468206642 3988293898 3988293899 3468206646
-                                3468206647 3468206644 3468206643],
+            'audienceIds' => %w[3468206642 3988293898 3988293899 3468206646 3468206647 3468206644 3468206643],
             'variations' => [
               {
                 'variables' => [],
@@ -838,8 +837,7 @@ module OptimizelySpec
             'endOfRange' => 10_000
           }
         ],
-        'audienceIds' => %w[3468206642 3988293898 3988293899 3468206646
-                            3468206647 3468206644 3468206643],
+        'audienceIds' => %w[3468206642 3988293898 3988293899 3468206646 3468206647 3468206644 3468206643],
         'variations' => [
           {
             'variables' => [
@@ -874,8 +872,7 @@ module OptimizelySpec
             'endOfRange' => 10_000
           }
         ],
-        'audienceIds' => %w[3468206642 3988293898 3988293899 3468206646
-                            3468206647 3468206644 3468206643],
+        'audienceIds' => %w[3468206642 3988293898 3988293899 3468206646 3468206647 3468206644 3468206643],
         'forcedVariations' => {}
       },
       {
@@ -966,6 +963,11 @@ module OptimizelySpec
         'conditions' => '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
       },
       {
+        'id' => '3468206645',
+        'name' => '$$dummyMultipleCustomAttrs',
+        'conditions' => '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
+      },
+      {
         'id' => '0',
         'name' => '$$dummy',
         'conditions' => '{ "type": "custom_attribute", "name": "$opt_dummy_attribute", "value": "impossible_value" }'
@@ -975,38 +977,44 @@ module OptimizelySpec
       {
         'id' => '3988293898',
         'name' => 'substringString',
-        'conditions' => '["and", ["or", ["or", '\
-  '{"name": "house", "type": "custom_attribute", "match":"substring", "value":"Slytherin"}]]]'
+        'conditions' => ['and', ['or', ['or', {'name' => 'house', 'type' => 'custom_attribute',
+                                               'match' => 'substring', 'value' => 'Slytherin'}]]]
       },
       {
         'id' => '3988293899',
         'name' => 'exists',
-        'conditions' => '["and", ["or", ["or", {"name": "favorite_ice_cream", "type": "custom_attribute",'\
-  '"match":"exists"}]]]'
+        'conditions' => ['and', ['or', ['or', {'name' => 'favorite_ice_cream', 'type' => 'custom_attribute',
+                                               'match' => 'exists'}]]]
       },
       {
         'id' => '3468206646',
         'name' => 'exactNumber',
-        'conditions' => '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute",'\
-  '"match":"exact", "value": 45.5}]]]'
+        'conditions' => ['and', ['or', ['or', {'name' => 'lasers', 'type' => 'custom_attribute',
+                                               'match' => 'exact', 'value' => 45.5}]]]
       },
       {
         'id' => '3468206647',
         'name' => 'gtNumber',
-        'conditions' => '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute",'\
-  '"match":"gt", "value": 70 }]]]'
+        'conditions' => ['and', ['or', ['or', {'name' => 'lasers', 'type' => 'custom_attribute',
+                                               'match' => 'gt', 'value' => 70}]]]
       },
       {
         'id' => '3468206644',
         'name' => 'ltNumber',
-        'conditions' => '["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute",'\
-  '"match":"lt", "value": 1.0 }]]]'
+        'conditions' => ['and', ['or', ['or', {'name' => 'lasers', 'type' => 'custom_attribute',
+                                               'match' => 'lt', 'value' => 1.0}]]]
       },
       {
         'id' => '3468206643',
         'name' => 'exactBoolean',
-        'conditions' => '["and", ["or", ["or", {"name": "should_do_it", "type": "custom_attribute",'\
-  '"match":"exact", "value": true}]]]'
+        'conditions' => ['and', ['or', ['or', {'name' => 'should_do_it', 'type' => 'custom_attribute',
+                                               'match' => 'exact', 'value' => true}]]]
+      },
+      {
+        'id' => '3468206645',
+        'name' => 'multiple_custom_attrs',
+        'conditions' => ['and', ['or', ['or', {'type' => 'custom_attribute', 'name' => 'browser', 'value' => 'chrome'},
+                                        {'type' => 'custom_attribute', 'name' => 'browser', 'value' => 'firefox'}]]]
       }
     ],
     'groups' => [],


### PR DESCRIPTION
Summary
-------
This adds support for audience combinations on experiments. If `experiment['audienceConditions']` is present, it will be used as a condition tree where the leaf conditions are audience Ids.

- Experiments can now be evaluated on behalf of either complex audienceConditions or simple audienceIds
- Audience conditions can either be a string defining array of conditions or simply a string of audience id which is then converted to an OR condition.
- Priority will be given to audienceConditions if both audienceIds and audienceConditions are present.

Test plan
---------
- test_optimizely - Added unit tests for APIs that pass/fail using various complex audiences with different match types. 
- Ran complex audiences test cases in compatibility test suite.

Issues
------

