### PR TITLE
ci: Adding support for testing on Ruby 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.3.7
   - 2.4.4
   - 2.5.1
+  - 2.6.0
 before_install:
   - gem update --system
   - gem install bundler

--- a/optimizely-sdk.gemspec
+++ b/optimizely-sdk.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop', '~> 0.60.0'
+  spec.add_development_dependency 'rubocop', '~> 0.62'
   spec.add_development_dependency 'webmock'
 
   spec.add_runtime_dependency 'httparty', '~> 0.11'


### PR DESCRIPTION
## Summary
- Added new ruby version (2.6.0) support.
- Updated rubocop version to 0.62 as it failed: https://github.com/rubocop-hq/rubocop/pull/6470
