### PR TITLE
feat(track): Introducing easier event tracking

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -207,7 +207,7 @@ module Optimizely
         return nil
       end
 
-      conversion_event = @event_builder.create_conversion_event(event_key, user_id, attributes, event_tags)
+      conversion_event = @event_builder.create_conversion_event(event, user_id, attributes, event_tags)
       @config.logger.log(Logger::INFO, "Tracking event '#{event_key}' for user '#{user_id}'.")
       @logger.log(Logger::INFO,
                   "Dispatching conversion event to URL #{conversion_event.url} with params #{conversion_event.params}.")

--- a/lib/optimizely/event_builder.rb
+++ b/lib/optimizely/event_builder.rb
@@ -143,10 +143,10 @@ module Optimizely
       Event.new(:post, ENDPOINT, event_params, POST_HEADERS)
     end
 
-    def create_conversion_event(event_key, user_id, attributes, event_tags)
+    def create_conversion_event(event, user_id, attributes, event_tags)
       # Create conversion Event to be sent to the logging endpoint.
       #
-      # event_key -                +String+ Event key representing the event which needs to be recorded.
+      # event -                    +Object+ Event which needs to be recorded.
       # user_id -                  +String+ ID for user.
       # attributes -               +Hash+ representing user attributes and values which need to be recorded.
       # event_tags -               +Hash+ representing metadata associated with the event.
@@ -154,7 +154,7 @@ module Optimizely
       # Returns +Event+ encapsulating the conversion event.
 
       event_params = get_common_params(user_id, attributes)
-      conversion_params = get_conversion_params(event_key, event_tags)
+      conversion_params = get_conversion_params(event, event_tags)
       event_params[:visitors][0][:snapshots] = [conversion_params]
 
       Event.new(:post, ENDPOINT, event_params, POST_HEADERS)
@@ -190,20 +190,20 @@ module Optimizely
       impression_event_params
     end
 
-    def get_conversion_params(event_key, event_tags)
+    def get_conversion_params(event, event_tags)
       # Creates object of params specific to conversion events
       #
-      # event_key -                +String+ Key representing the event which needs to be recorded
+      # event -                    +Object+ Event which needs to be recorded.
       # event_tags -               +Hash+ Values associated with the event.
       #
       # Returns +Hash+ Conversion event params
 
       single_snapshot = {}
       event_object = {
-        entity_id: @config.event_key_map[event_key]['id'],
+        entity_id: event['id'],
         timestamp: create_timestamp,
         uuid: create_uuid,
-        key: event_key
+        key: event['key']
       }
 
       if event_tags

--- a/lib/optimizely/project_config.rb
+++ b/lib/optimizely/project_config.rb
@@ -185,19 +185,19 @@ module Optimizely
       nil
     end
 
-    def get_experiment_ids_for_event(event_key)
-      # Get experiment IDs for the provided event key.
+    def get_event_from_key(event_key)
+      # Get event for the provided event key.
       #
-      # event_key - Event key for which experiment IDs are to be retrieved.
+      # event_key - Event key for which event is to be determined.
       #
-      # Returns array of all experiment IDs for the event.
+      # Returns Event corresponding to the provided event key.
 
       event = @event_key_map[event_key]
-      return event['experimentIds'] if event
+      return event if event
 
       @logger.log Logger::ERROR, "Event '#{event_key}' is not in datafile."
       @error_handler.handle_error InvalidEventError
-      []
+      nil
     end
 
     def get_audience_from_id(audience_id)

--- a/spec/event_builder_spec.rb
+++ b/spec/event_builder_spec.rb
@@ -33,6 +33,7 @@ describe Optimizely::EventBuilder do
   before(:example) do
     config = Optimizely::ProjectConfig.new(@config_body_json, @logger, @error_handler)
     @event_builder = Optimizely::EventBuilder.new(config, @logger)
+    @event = config.get_event_from_key('test_event')
 
     time_now = Time.now
     allow(Time).to receive(:now).and_return(time_now)
@@ -238,7 +239,7 @@ describe Optimizely::EventBuilder do
   end
 
   it 'should create a valid Event when create_conversion_event is called' do
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, nil)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -252,7 +253,7 @@ describe Optimizely::EventBuilder do
       value: 'firefox'
     )
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', {'browser_type' => 'firefox'}, nil)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', {'browser_type' => 'firefox'}, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -264,7 +265,7 @@ describe Optimizely::EventBuilder do
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0].merge!(revenue: 4200,
                                                                                 tags: event_tags)
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -276,7 +277,7 @@ describe Optimizely::EventBuilder do
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0].merge!(revenue: 4200,
                                                                                 tags: event_tags)
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -287,7 +288,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -298,7 +299,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -313,7 +314,7 @@ describe Optimizely::EventBuilder do
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0].merge!(revenue: 4200,
                                                                                 tags: event_tags)
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -327,7 +328,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -340,7 +341,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -353,7 +354,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -366,7 +367,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -380,7 +381,7 @@ describe Optimizely::EventBuilder do
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0].merge!(value: 13.37,
                                                                                 tags: event_tags)
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -393,7 +394,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -418,7 +419,7 @@ describe Optimizely::EventBuilder do
       value: 'firefox'
     )
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', {'browser_type' => 'firefox'}, event_tags)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', {'browser_type' => 'firefox'}, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -527,7 +528,7 @@ describe Optimizely::EventBuilder do
       'browser_type' => 'firefox',
       '$opt_bucketing_id' => 'variation'
     }
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', user_attributes, nil)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', user_attributes, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -548,7 +549,7 @@ describe Optimizely::EventBuilder do
     user_attributes = {
       '$opt_user_agent' => 'test'
     }
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', user_attributes, nil)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', user_attributes, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -576,7 +577,7 @@ describe Optimizely::EventBuilder do
       '$opt_user_agent' => 'test'
     }
     allow(@event_builder).to receive(:bot_filtering).and_return(false)
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', user_attributes, nil)
+    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', user_attributes, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)

--- a/spec/event_builder_spec.rb
+++ b/spec/event_builder_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2018, Optimizely and contributors
+#    Copyright 2016-2019, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ describe Optimizely::EventBuilder do
       anonymize_ip: false,
       revision: '42',
       client_name: Optimizely::CLIENT_ENGINE,
+      enrich_decisions: true,
       client_version: Optimizely::VERSION
     }
     @expected_conversion_params = {
@@ -81,11 +82,6 @@ describe Optimizely::EventBuilder do
         }],
         visitor_id: 'test_user',
         snapshots: [{
-          decisions: [{
-            campaign_id: '1',
-            experiment_id: '111127',
-            variation_id: '111128'
-          }],
           events: [{
             entity_id: '111095',
             timestamp: (time_now.to_f * 1000).to_i,
@@ -97,6 +93,7 @@ describe Optimizely::EventBuilder do
       anonymize_ip: false,
       revision: '42',
       client_name: Optimizely::CLIENT_ENGINE,
+      enrich_decisions: true,
       client_version: Optimizely::VERSION
     }
   end
@@ -241,7 +238,7 @@ describe Optimizely::EventBuilder do
   end
 
   it 'should create a valid Event when create_conversion_event is called' do
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, nil, '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -255,8 +252,7 @@ describe Optimizely::EventBuilder do
       value: 'firefox'
     )
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', {'browser_type' => 'firefox'},
-                                                              nil, '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', {'browser_type' => 'firefox'}, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -268,8 +264,7 @@ describe Optimizely::EventBuilder do
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0].merge!(revenue: 4200,
                                                                                 tags: event_tags)
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -281,8 +276,7 @@ describe Optimizely::EventBuilder do
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0].merge!(revenue: 4200,
                                                                                 tags: event_tags)
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -293,8 +287,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -305,8 +298,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -321,8 +313,7 @@ describe Optimizely::EventBuilder do
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0].merge!(revenue: 4200,
                                                                                 tags: event_tags)
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -336,8 +327,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -350,8 +340,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -364,8 +353,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -378,8 +366,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -393,8 +380,7 @@ describe Optimizely::EventBuilder do
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0].merge!(value: 13.37,
                                                                                 tags: event_tags)
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -407,8 +393,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -433,8 +418,7 @@ describe Optimizely::EventBuilder do
       value: 'firefox'
     )
 
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', {'browser_type' => 'firefox'},
-                                                              event_tags, '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', {'browser_type' => 'firefox'}, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -543,8 +527,7 @@ describe Optimizely::EventBuilder do
       'browser_type' => 'firefox',
       '$opt_bucketing_id' => 'variation'
     }
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', user_attributes, nil,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', user_attributes, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -565,8 +548,7 @@ describe Optimizely::EventBuilder do
     user_attributes = {
       '$opt_user_agent' => 'test'
     }
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', user_attributes, nil,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', user_attributes, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -594,29 +576,9 @@ describe Optimizely::EventBuilder do
       '$opt_user_agent' => 'test'
     }
     allow(@event_builder).to receive(:bot_filtering).and_return(false)
-    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', user_attributes, nil,
-                                                              '111127' => '111128')
+    conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', user_attributes, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
-  end
-
-  describe 'multiple_experiments_event' do
-    it 'should create_conversion_event when Event is used in multiple experiments' do
-      @expected_conversion_params[:visitors][0][:snapshots][0][:decisions] = [{
-        campaign_id: '1',
-        experiment_id: '111127',
-        variation_id: '111128'
-      }, {
-        campaign_id: '4',
-        experiment_id: '122230',
-        variation_id: '122231'
-      }]
-
-      conversion_event = @event_builder.create_conversion_event('test_event', 'test_user', nil, nil, '111127' => '111128', '122230' => '122231')
-      expect(conversion_event.params).to eq(@expected_conversion_params)
-      expect(conversion_event.url).to eq(@expected_endpoint)
-      expect(conversion_event.http_verb).to eq(:post)
-    end
   end
 end

--- a/spec/project_config_spec.rb
+++ b/spec/project_config_spec.rb
@@ -792,7 +792,7 @@ describe Optimizely::ProjectConfig do
       end
     end
 
-    describe 'get_experiment_ids_for_event' do
+    describe 'get_event_from_key' do
       it 'should raise an error when provided event key is invalid' do
         expect { config.get_event_from_key('invalid_key') }.to raise_error(Optimizely::InvalidEventError)
       end

--- a/spec/project_config_spec.rb
+++ b/spec/project_config_spec.rb
@@ -702,9 +702,9 @@ describe Optimizely::ProjectConfig do
       end
     end
 
-    describe 'get_experiment_ids_for_event' do
+    describe 'get_event_from_key' do
       it 'should log a message when provided event key is invalid' do
-        config.get_experiment_ids_for_event('invalid_key')
+        config.get_event_from_key('invalid_key')
         expect(spy_logger).to have_received(:log).with(Logger::ERROR, "Event 'invalid_key' is not in datafile.")
       end
     end
@@ -794,7 +794,7 @@ describe Optimizely::ProjectConfig do
 
     describe 'get_experiment_ids_for_event' do
       it 'should raise an error when provided event key is invalid' do
-        expect { config.get_experiment_ids_for_event('invalid_key') }.to raise_error(Optimizely::InvalidEventError)
+        expect { config.get_event_from_key('invalid_key') }.to raise_error(Optimizely::InvalidEventError)
       end
     end
 


### PR DESCRIPTION
## Summary
- Impression/Conversion events now have a 'enrich_decisions' boolean property set to true.
- conversion events now do not have the decision property in visitor snapshots. 
- Conversion event is now sent solely if the event key corresponds to a valid event in the data file.

## Test plan
- Unit Tests updated
- Tested Compat Suite Tests for EET locally. 

## Issues
- OASIS-4031
