### PR TITLE
feat(DecisionListener): Adds experiment decision listener.

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -148,7 +148,7 @@ module Optimizely
 
       @notification_center.send_notifications(
         NotificationCenter::NOTIFICATION_TYPES[:DECISION],
-        Helpers::Constants::DECISION_INFO_TYPES['EXPERIMENT'], user_id, attributes,
+        Helpers::Constants::DECISION_INFO_TYPES['EXPERIMENT'], user_id, (attributes || {}),
         decision_info: {
           experiment_key: experiment_key,
           variation_key: variation_key

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -147,7 +147,7 @@ module Optimizely
       variation_key = variation['key'] if variation
 
       @notification_center.send_notifications(
-        NotificationCenter::NOTIFICATION_TYPES[:ON_DECISION],
+        NotificationCenter::NOTIFICATION_TYPES[:DECISION],
         Helpers::Constants::DECISION_INFO_TYPES['EXPERIMENT'], user_id, attributes,
         decision_info: {
           experiment_key: experiment_key,

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -149,10 +149,8 @@ module Optimizely
       @notification_center.send_notifications(
         NotificationCenter::NOTIFICATION_TYPES[:DECISION],
         Helpers::Constants::DECISION_INFO_TYPES['EXPERIMENT'], user_id, (attributes || {}),
-        decision_info: {
-          experiment_key: experiment_key,
-          variation_key: variation_key
-        }
+        experiment_key: experiment_key,
+        variation_key: variation_key
       )
 
       variation_key

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -143,12 +143,19 @@ module Optimizely
       end
 
       variation_id = @decision_service.get_variation(experiment_key, user_id, attributes)
+      variation = @config.get_variation_from_id(experiment_key, variation_id) unless variation_id.nil?
+      variation_key = variation['key'] if variation
 
-      unless variation_id.nil?
-        variation = @config.get_variation_from_id(experiment_key, variation_id)
-        return variation['key'] if variation
-      end
-      nil
+      @notification_center.send_notifications(
+        NotificationCenter::NOTIFICATION_TYPES[:ON_DECISION],
+        Helpers::Constants::DECISION_INFO_TYPES['EXPERIMENT'], user_id, attributes,
+        decision_info: {
+          experiment_key: experiment_key,
+          variation_key: variation_key
+        }
+      )
+
+      variation_key
     end
 
     # Force a user into a variation for a given experiment.

--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -352,6 +352,12 @@ module Optimizely
         'UNKNOWN_MATCH_TYPE' => 'Audience condition %s uses an unknown match type. You may need ' \
         'to upgrade to a newer release of the Optimizely SDK.'
       }.freeze
+
+      DECISION_INFO_TYPES = {
+        'EXPERIMENT' => 'experiment',
+        'FEATURE' => 'feature',
+        'FEATURE_VARIABLE' => 'feature_variable'
+      }.freeze
     end
   end
 end

--- a/lib/optimizely/notification_center.rb
+++ b/lib/optimizely/notification_center.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2017-2018, Optimizely and contributors
+#    Copyright 2017-2019, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ module Optimizely
 
     NOTIFICATION_TYPES = {
       ACTIVATE: 'ACTIVATE: experiment, user_id, attributes, variation, event',
+      ON_DECISION: 'ON_DECISION: type, user_id, attributes, decision_info',
       TRACK: 'TRACK: event_key, user_id, attributes, event_tags, event'
     }.freeze
 

--- a/lib/optimizely/notification_center.rb
+++ b/lib/optimizely/notification_center.rb
@@ -22,7 +22,7 @@ module Optimizely
 
     NOTIFICATION_TYPES = {
       ACTIVATE: 'ACTIVATE: experiment, user_id, attributes, variation, event',
-      ON_DECISION: 'ON_DECISION: type, user_id, attributes, decision_info',
+      DECISION: 'DECISION: type, user_id, attributes, decision_info',
       TRACK: 'TRACK: event_key, user_id, attributes, event_tags, event'
     }.freeze
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -659,9 +659,7 @@ describe 'Optimizely' do
         expect(project_instance.notification_center).to receive(:send_notifications).with(
           Optimizely::NotificationCenter::NOTIFICATION_TYPES[:DECISION],
           'experiment', 'test_user', {'browser_type' => 'chrome'},
-          decision_info: {
-            experiment_key: 'test_experiment_with_audience', variation_key: nil
-          }
+          experiment_key: 'test_experiment_with_audience', variation_key: nil
         )
 
         project_instance.activate('test_experiment_with_audience', 'test_user', 'browser_type' => 'chrome')
@@ -678,7 +676,7 @@ describe 'Optimizely' do
         expect(project_instance.notification_center).to receive(:send_notifications).with(
           Optimizely::NotificationCenter::NOTIFICATION_TYPES[:DECISION],
           'experiment', 'test_user', {},
-          decision_info: {experiment_key: 'test_experiment', variation_key: 'control'}
+          experiment_key: 'test_experiment', variation_key: 'control'
         ).ordered
 
         expect(project_instance.notification_center).to receive(:send_notifications).ordered
@@ -1345,7 +1343,7 @@ describe 'Optimizely' do
         expect(project_instance.notification_center).to receive(:send_notifications).with(
           Optimizely::NotificationCenter::NOTIFICATION_TYPES[:DECISION],
           'experiment', 'test_user', {'browser_type' => 'firefox'},
-          decision_info: {experiment_key: 'test_experiment_with_audience', variation_key: 'control_with_audience'}
+          experiment_key: 'test_experiment_with_audience', variation_key: 'control_with_audience'
         )
 
         project_instance.get_variation('test_experiment_with_audience', 'test_user', 'browser_type' => 'firefox')
@@ -1355,7 +1353,7 @@ describe 'Optimizely' do
         expect(project_instance.notification_center).to receive(:send_notifications).with(
           Optimizely::NotificationCenter::NOTIFICATION_TYPES[:DECISION],
           'experiment', 'test_user', {'browser_type' => 'chrome'},
-          decision_info: {experiment_key: 'test_experiment_with_audience', variation_key: nil}
+          experiment_key: 'test_experiment_with_audience', variation_key: nil
         )
 
         project_instance.get_variation('test_experiment_with_audience', 'test_user', 'browser_type' => 'chrome')

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -677,7 +677,7 @@ describe 'Optimizely' do
 
         expect(project_instance.notification_center).to receive(:send_notifications).with(
           Optimizely::NotificationCenter::NOTIFICATION_TYPES[:DECISION],
-          'experiment', 'test_user', nil,
+          'experiment', 'test_user', {},
           decision_info: {experiment_key: 'test_experiment', variation_key: 'control'}
         ).ordered
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -593,8 +593,10 @@ describe 'Optimizely' do
         .and_return([])
       experiment = project_instance.config.get_experiment_from_key('test_experiment')
 
+      # Decision listener
       expect(project_instance.notification_center).to receive(:send_notifications).ordered
 
+      # Activate listener
       expect(project_instance.notification_center).to receive(:send_notifications).with(
         Optimizely::NotificationCenter::NOTIFICATION_TYPES[:ACTIVATE],
         experiment, 'test_user', nil, variation_to_return,
@@ -658,27 +660,26 @@ describe 'Optimizely' do
       it 'should call decision listener when user not in experiment' do
         expect(project_instance.notification_center).to receive(:send_notifications).with(
           Optimizely::NotificationCenter::NOTIFICATION_TYPES[:DECISION],
-          'experiment', 'test_user', {'browser_type' => 'chrome'},
+          'experiment', 'test_user', {},
           experiment_key: 'test_experiment_with_audience', variation_key: nil
         )
 
-        project_instance.activate('test_experiment_with_audience', 'test_user', 'browser_type' => 'chrome')
+        project_instance.activate('test_experiment_with_audience', 'test_user')
       end
 
       it 'should call decision listener when user in experiment' do
         variation_to_return = project_instance.config.get_variation_from_id('test_experiment', '111128')
         allow(project_instance.decision_service.bucketer).to receive(:bucket).and_return(variation_to_return)
-        allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
-        allow(project_instance.config).to receive(:get_audience_ids_for_experiment)
-          .with('test_experiment')
-          .and_return([])
+        expect(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
 
+        # Decision listener
         expect(project_instance.notification_center).to receive(:send_notifications).with(
           Optimizely::NotificationCenter::NOTIFICATION_TYPES[:DECISION],
           'experiment', 'test_user', {},
           experiment_key: 'test_experiment', variation_key: 'control'
         ).ordered
 
+        # Activate listener
         expect(project_instance.notification_center).to receive(:send_notifications).ordered
 
         project_instance.activate('test_experiment', 'test_user')
@@ -1101,6 +1102,28 @@ describe 'Optimizely' do
       invalid_project = Optimizely::Project.new('invalid')
       invalid_project.get_variation('test_exp', 'test_user')
     end
+
+    describe '.decision listener' do
+      it 'should call decision listener when user in experiment' do
+        expect(project_instance.notification_center).to receive(:send_notifications).with(
+          Optimizely::NotificationCenter::NOTIFICATION_TYPES[:DECISION],
+          'experiment', 'test_user', {'browser_type' => 'firefox'},
+          experiment_key: 'test_experiment_with_audience', variation_key: 'control_with_audience'
+        )
+
+        project_instance.get_variation('test_experiment_with_audience', 'test_user', 'browser_type' => 'firefox')
+      end
+
+      it 'should call decision listener when user not in experiment' do
+        expect(project_instance.notification_center).to receive(:send_notifications).with(
+          Optimizely::NotificationCenter::NOTIFICATION_TYPES[:DECISION],
+          'experiment', 'test_user', {'browser_type' => 'chrome'},
+          experiment_key: 'test_experiment_with_audience', variation_key: nil
+        )
+
+        project_instance.get_variation('test_experiment_with_audience', 'test_user', 'browser_type' => 'chrome')
+      end
+    end
   end
 
   describe '#is_feature_enabled' do
@@ -1336,28 +1359,6 @@ describe 'Optimizely' do
       expect(project_instance.is_feature_enabled('multi_variate_feature', 'test_user')).to be false
       expect(project_instance.event_dispatcher).to have_received(:dispatch_event).with(instance_of(Optimizely::Event)).once
       expect(spy_logger).to have_received(:log).once.with(Logger::INFO, "Feature 'multi_variate_feature' is not enabled for user 'test_user'.")
-    end
-
-    describe '.decision listener' do
-      it 'should call decision listener when user in experiment' do
-        expect(project_instance.notification_center).to receive(:send_notifications).with(
-          Optimizely::NotificationCenter::NOTIFICATION_TYPES[:DECISION],
-          'experiment', 'test_user', {'browser_type' => 'firefox'},
-          experiment_key: 'test_experiment_with_audience', variation_key: 'control_with_audience'
-        )
-
-        project_instance.get_variation('test_experiment_with_audience', 'test_user', 'browser_type' => 'firefox')
-      end
-
-      it 'should call decision listener when user not in experiment' do
-        expect(project_instance.notification_center).to receive(:send_notifications).with(
-          Optimizely::NotificationCenter::NOTIFICATION_TYPES[:DECISION],
-          'experiment', 'test_user', {'browser_type' => 'chrome'},
-          experiment_key: 'test_experiment_with_audience', variation_key: nil
-        )
-
-        project_instance.get_variation('test_experiment_with_audience', 'test_user', 'browser_type' => 'chrome')
-      end
     end
   end
 


### PR DESCRIPTION
Summary
-------
Implemented onDecisionListener in following APIs:
- activate
- get_variation

Test plan
---------
Unit tests for OnDecisionListener

Issues
------
- OASIS-4233