### PR TITLE
ci: use script from travisci-tools repo to trigger tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,11 @@ jobs:
       merge_mode: replace
       env: SDK=ruby
       cache: false
-      language: python
+      language: minimal
       before_install: skip
-      install:
-        - "pip install awscli"
+      install: skip
       before_script:
-        - "aws s3 cp s3://optimizely-travisci-artifacts/ci/trigger_fullstack-sdk-compat.sh ci/ && chmod u+x ci/trigger_fullstack-sdk-compat.sh"
+        - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
       script:
-        - "ci/trigger_fullstack-sdk-compat.sh"
+        - "$HOME/travisci-tools/fsc-trigger/trigger_fullstack-sdk-compat.sh"
       after_success: travis_terminate 0


### PR DESCRIPTION
## Summary
This uses the script from travisci-tools repo to trigger compat suite. 

## Test plan

## Issues
OASIS-4389