### PR TITLE
Refactoring and passing ProjectConfig from Optimizely.

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -74,8 +74,8 @@ module Optimizely
         return
       end
 
-      @decision_service = DecisionService.new(@config, @user_profile_service)
-      @event_builder = EventBuilder.new(@config, @logger)
+      @decision_service = DecisionService.new(@logger, @user_profile_service)
+      @event_builder = EventBuilder.new(@logger)
       @notification_center = NotificationCenter.new(@logger, @error_handler)
     end
 
@@ -145,7 +145,7 @@ module Optimizely
         return nil
       end
 
-      variation_id = @decision_service.get_variation(experiment_key, user_id, attributes)
+      variation_id = @decision_service.get_variation(@config, experiment_key, user_id, attributes)
       variation = @config.get_variation_from_id(experiment_key, variation_id) unless variation_id.nil?
       variation_key = variation['key'] if variation
       decision_notification_type = if @config.feature_experiment?(experiment['id'])
@@ -219,7 +219,7 @@ module Optimizely
         return nil
       end
 
-      conversion_event = @event_builder.create_conversion_event(event, user_id, attributes, event_tags)
+      conversion_event = @event_builder.create_conversion_event(@config, event, user_id, attributes, event_tags)
       @config.logger.log(Logger::INFO, "Tracking event '#{event_key}' for user '#{user_id}'.")
       @logger.log(Logger::INFO,
                   "Dispatching conversion event to URL #{conversion_event.url} with params #{conversion_event.params}.")
@@ -268,7 +268,7 @@ module Optimizely
         return false
       end
 
-      decision = @decision_service.get_variation_for_feature(feature_flag, user_id, attributes)
+      decision = @decision_service.get_variation_for_feature(@config, feature_flag, user_id, attributes)
 
       feature_enabled = false
       source_string = Optimizely::DecisionService::DECISION_SOURCES['ROLLOUT']
@@ -496,7 +496,7 @@ module Optimizely
         return nil
       else
         source_string = Optimizely::DecisionService::DECISION_SOURCES['ROLLOUT']
-        decision = @decision_service.get_variation_for_feature(feature_flag, user_id, attributes)
+        decision = @decision_service.get_variation_for_feature(@config, feature_flag, user_id, attributes)
         variable_value = variable['defaultValue']
         if decision
           variation = decision['variation']
@@ -592,7 +592,7 @@ module Optimizely
     def send_impression(experiment, variation_key, user_id, attributes = nil)
       experiment_key = experiment['key']
       variation_id = @config.get_variation_id_from_key(experiment_key, variation_key)
-      impression_event = @event_builder.create_impression_event(experiment, variation_id, user_id, attributes)
+      impression_event = @event_builder.create_impression_event(@config, experiment, variation_id, user_id, attributes)
       @logger.log(Logger::INFO,
                   "Dispatching impression event to URL #{impression_event.url} with params #{impression_event.params}.")
       begin

--- a/spec/event_builder_spec.rb
+++ b/spec/event_builder_spec.rb
@@ -32,7 +32,7 @@ describe Optimizely::EventBuilder do
 
   before(:example) do
     config = Optimizely::ProjectConfig.new(@config_body_json, @logger, @error_handler)
-    @event_builder = Optimizely::EventBuilder.new(config, @logger)
+    @event_builder = Optimizely::EventBuilder.new(@logger)
     @event = config.get_event_from_key('test_event')
 
     time_now = Time.now
@@ -101,7 +101,7 @@ describe Optimizely::EventBuilder do
 
   it 'should create valid Event when create_impression_event is called without attributes' do
     experiment = config.get_experiment_from_key('test_experiment')
-    impression_event = @event_builder.create_impression_event(experiment, '111128', 'test_user', nil)
+    impression_event = @event_builder.create_impression_event(config, experiment, '111128', 'test_user', nil)
     expect(impression_event.params).to eq(@expected_impression_params)
     expect(impression_event.url).to eq(@expected_endpoint)
     expect(impression_event.http_verb).to eq(:post)
@@ -116,7 +116,7 @@ describe Optimizely::EventBuilder do
     )
 
     experiment = config.get_experiment_from_key('test_experiment')
-    impression_event = @event_builder.create_impression_event(experiment, '111128', 'test_user',
+    impression_event = @event_builder.create_impression_event(config, experiment, '111128', 'test_user',
                                                               'browser_type' => 'firefox')
     expect(impression_event.params).to eq(@expected_impression_params)
     expect(impression_event.url).to eq(@expected_endpoint)
@@ -159,7 +159,7 @@ describe Optimizely::EventBuilder do
       'integer_key' => 5,
       'double_key' => 5.5
     }
-    impression_event = @event_builder.create_impression_event(experiment, '111128', 'test_user', attributes)
+    impression_event = @event_builder.create_impression_event(config, experiment, '111128', 'test_user', attributes)
     expect(impression_event.params).to eq(@expected_impression_params)
     expect(impression_event.url).to eq(@expected_endpoint)
     expect(impression_event.http_verb).to eq(:post)
@@ -192,7 +192,7 @@ describe Optimizely::EventBuilder do
       'integer_key' => 5,
       'double_key' => {}
     }
-    impression_event = @event_builder.create_impression_event(experiment, '111128', 'test_user', attributes)
+    impression_event = @event_builder.create_impression_event(config, experiment, '111128', 'test_user', attributes)
     expect(impression_event.params).to eq(@expected_impression_params)
     expect(impression_event.url).to eq(@expected_endpoint)
     expect(impression_event.http_verb).to eq(:post)
@@ -207,7 +207,7 @@ describe Optimizely::EventBuilder do
     )
 
     experiment = config.get_experiment_from_key('test_experiment')
-    impression_event = @event_builder.create_impression_event(experiment, '111128', 'test_user',
+    impression_event = @event_builder.create_impression_event(config, experiment, '111128', 'test_user',
                                                               'browser_type' => false)
     expect(impression_event.params).to eq(@expected_impression_params)
     expect(impression_event.url).to eq(@expected_endpoint)
@@ -223,7 +223,7 @@ describe Optimizely::EventBuilder do
     )
 
     experiment = config.get_experiment_from_key('test_experiment')
-    impression_event = @event_builder.create_impression_event(experiment, '111128', 'test_user', 'browser_type' => 0)
+    impression_event = @event_builder.create_impression_event(config, experiment, '111128', 'test_user', 'browser_type' => 0)
     expect(impression_event.params).to eq(@expected_impression_params)
     expect(impression_event.url).to eq(@expected_endpoint)
     expect(impression_event.http_verb).to eq(:post)
@@ -231,7 +231,7 @@ describe Optimizely::EventBuilder do
 
   it 'should create a valid Event when create_impression_event is called with attributes is not in the datafile' do
     experiment = config.get_experiment_from_key('test_experiment')
-    impression_event = @event_builder.create_impression_event(experiment, '111128', 'test_user',
+    impression_event = @event_builder.create_impression_event(config, experiment, '111128', 'test_user',
                                                               invalid_attribute: 'sorry_not_sorry')
     expect(impression_event.params).to eq(@expected_impression_params)
     expect(impression_event.url).to eq(@expected_endpoint)
@@ -239,7 +239,7 @@ describe Optimizely::EventBuilder do
   end
 
   it 'should create a valid Event when create_conversion_event is called' do
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, nil)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', nil, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -253,7 +253,7 @@ describe Optimizely::EventBuilder do
       value: 'firefox'
     )
 
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', {'browser_type' => 'firefox'}, nil)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', {'browser_type' => 'firefox'}, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -265,7 +265,7 @@ describe Optimizely::EventBuilder do
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0].merge!(revenue: 4200,
                                                                                 tags: event_tags)
 
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -277,7 +277,7 @@ describe Optimizely::EventBuilder do
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0].merge!(revenue: 4200,
                                                                                 tags: event_tags)
 
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -288,7 +288,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -299,7 +299,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -314,7 +314,7 @@ describe Optimizely::EventBuilder do
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0].merge!(revenue: 4200,
                                                                                 tags: event_tags)
 
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -328,7 +328,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -341,7 +341,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -354,7 +354,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -367,7 +367,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -381,7 +381,7 @@ describe Optimizely::EventBuilder do
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0].merge!(value: 13.37,
                                                                                 tags: event_tags)
 
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -394,7 +394,7 @@ describe Optimizely::EventBuilder do
 
     @expected_conversion_params[:visitors][0][:snapshots][0][:events][0][:tags] = event_tags
 
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', nil, event_tags)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', nil, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -419,7 +419,7 @@ describe Optimizely::EventBuilder do
       value: 'firefox'
     )
 
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', {'browser_type' => 'firefox'}, event_tags)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', {'browser_type' => 'firefox'}, event_tags)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -445,7 +445,7 @@ describe Optimizely::EventBuilder do
       '$opt_bucketing_id' => 'variation'
     }
     experiment = config.get_experiment_from_key('test_experiment')
-    impression_event = @event_builder.create_impression_event(experiment, '111128', 'test_user', user_attributes)
+    impression_event = @event_builder.create_impression_event(config, experiment, '111128', 'test_user', user_attributes)
     expect(impression_event.params).to eq(@expected_impression_params)
     expect(impression_event.url).to eq(@expected_endpoint)
     expect(impression_event.http_verb).to eq(:post)
@@ -473,8 +473,8 @@ describe Optimizely::EventBuilder do
       '$opt_user_agent' => 'test'
     }
     experiment = config.get_experiment_from_key('test_experiment')
-    expect(@event_builder.send(:bot_filtering)).to eq(true)
-    impression_event = @event_builder.create_impression_event(experiment, '111128', 'test_user', user_attributes)
+    expect(config.send(:bot_filtering)).to eq(true)
+    impression_event = @event_builder.create_impression_event(config, experiment, '111128', 'test_user', user_attributes)
     expect(impression_event.params).to eq(@expected_impression_params)
     expect(impression_event.url).to eq(@expected_endpoint)
     expect(impression_event.http_verb).to eq(:post)
@@ -502,8 +502,8 @@ describe Optimizely::EventBuilder do
       '$opt_user_agent' => 'test'
     }
     experiment = config.get_experiment_from_key('test_experiment')
-    allow(@event_builder).to receive(:bot_filtering).and_return(false)
-    impression_event = @event_builder.create_impression_event(experiment, '111128', 'test_user', user_attributes)
+    allow(config).to receive(:bot_filtering).and_return(false)
+    impression_event = @event_builder.create_impression_event(config, experiment, '111128', 'test_user', user_attributes)
     expect(impression_event.params).to eq(@expected_impression_params)
     expect(impression_event.url).to eq(@expected_endpoint)
     expect(impression_event.http_verb).to eq(:post)
@@ -528,7 +528,7 @@ describe Optimizely::EventBuilder do
       'browser_type' => 'firefox',
       '$opt_bucketing_id' => 'variation'
     }
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', user_attributes, nil)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', user_attributes, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -549,7 +549,7 @@ describe Optimizely::EventBuilder do
     user_attributes = {
       '$opt_user_agent' => 'test'
     }
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', user_attributes, nil)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', user_attributes, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)
@@ -576,8 +576,8 @@ describe Optimizely::EventBuilder do
     user_attributes = {
       '$opt_user_agent' => 'test'
     }
-    allow(@event_builder).to receive(:bot_filtering).and_return(false)
-    conversion_event = @event_builder.create_conversion_event(@event, 'test_user', user_attributes, nil)
+    allow(config).to receive(:bot_filtering).and_return(false)
+    conversion_event = @event_builder.create_conversion_event(config, @event, 'test_user', user_attributes, nil)
     expect(conversion_event.params).to eq(@expected_conversion_params)
     expect(conversion_event.url).to eq(@expected_endpoint)
     expect(conversion_event.http_verb).to eq(:post)

--- a/spec/notification_center_spec.rb
+++ b/spec/notification_center_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2017-2018, Optimizely and contributors
+#    Copyright 2017-2019, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -411,14 +411,14 @@ describe Optimizely::NotificationCenter do
       let(:notification_center) { Optimizely::NotificationCenter.new(spy_logger, raise_error_handler) }
       before(:example) do
         config = Optimizely::ProjectConfig.new(config_body_JSON, spy_logger, error_handler)
-        @event_builder = Optimizely::EventBuilder.new(config, spy_logger)
+        @event_builder = Optimizely::EventBuilder.new(spy_logger)
         @args = [
           config.get_experiment_from_key('test_experiment'),
           'test_user',
           {},
           '111128',
           @event_builder.create_impression_event(
-            config.get_experiment_from_key('test_experiment'),
+            config, config.get_experiment_from_key('test_experiment'),
             '111128', 'test_user', nil
           )
         ]


### PR DESCRIPTION
Summary
-------
 - Moved out ProjectConfig from `Bucketer`, `DecisionService` and `EventBuilder`. Project Config will now only be passed on method calls. 

Test plan
---------

Unit tests and compatibility suite tests continue to pass.