### PR TITLE
Fix: Rubocop latest version issues

### DIFF
--- a/optimizely-sdk.gemspec
+++ b/optimizely-sdk.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop', '~> 0.62'
+  spec.add_development_dependency 'rubocop', '0.73.0'
   spec.add_development_dependency 'webmock'
 
   spec.add_runtime_dependency 'httparty', '~> 0.11'

--- a/spec/custom_attribute_condition_evaluator_spec.rb
+++ b/spec/custom_attribute_condition_evaluator_spec.rb
@@ -325,7 +325,7 @@ describe Optimizely::CustomAttributeConditionEvaluator do
       expect(spy_logger).to have_received(:log).once.with(
         Logger::WARN,
         "Audience condition #{@substring_conditions} has an unsupported condition value. You may need to upgrade "\
-					'to a newer release of the Optimizely SDK.'
+          'to a newer release of the Optimizely SDK.'
       )
     end
   end
@@ -437,7 +437,7 @@ describe Optimizely::CustomAttributeConditionEvaluator do
       expect(spy_logger).to have_received(:log).once.with(
         Logger::WARN,
         "Audience condition #{@gt_integer_conditions} has an unsupported condition value. You may need to upgrade "\
-  					'to a newer release of the Optimizely SDK.'
+            'to a newer release of the Optimizely SDK.'
       )
     end
   end
@@ -549,7 +549,7 @@ describe Optimizely::CustomAttributeConditionEvaluator do
       expect(spy_logger).to have_received(:log).once.with(
         Logger::WARN,
         "Audience condition #{@lt_integer_conditions} has an unsupported condition value. You may need to upgrade "\
-					'to a newer release of the Optimizely SDK.'
+          'to a newer release of the Optimizely SDK.'
       )
     end
   end


### PR DESCRIPTION
## Summary
- Rubocop 0.73 has been released; https://github.com/rubocop-hq/rubocop/releases
- Travis builds are getting failed due to this new release; https://travis-ci.org/optimizely/ruby-sdk/jobs/559878094
- Used latest version and resolved lint errors.