### PR TITLE
Include LICENSE file in built gem

### DIFF
--- a/optimizely-sdk.gemspec
+++ b/optimizely-sdk.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://www.optimizely.com/'
   spec.license       = 'Apache-2.0'
 
-  spec.files         = Dir['lib/**/*']
+  spec.files         = Dir['lib/**/*', 'LICENSE']
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Per the rubygems guidelines, license files should be included in the
packaged gem. https://guides.rubygems.org/specification-reference/#license=

> The full text of the license should be inside of the gem (at the top level) when you build it.
