### PR TITLE
(fix): fix loop on batch event processor

### DIFF
--- a/lib/optimizely/event/batch_event_processor.rb
+++ b/lib/optimizely/event/batch_event_processor.rb
@@ -119,7 +119,7 @@ module Optimizely
 
         if item.nil?
           sleep(@flushing_interval_deadline - Helpers::DateTimeUtils.create_timestamp)
-          @nil_count++
+          @nil_count += 1
           next
         end
 

--- a/lib/optimizely/event/batch_event_processor.rb
+++ b/lib/optimizely/event/batch_event_processor.rb
@@ -108,7 +108,10 @@ module Optimizely
     private
 
     def run
+      # if we receive a number of item nils that reach MAX_NIL_COUNT,
+      # then we hang on the pop via setting use_pop to false
       @nil_count = 0
+      # hang on pop if true
       @use_pop = false
       loop do
         if Helpers::DateTimeUtils.create_timestamp >= @flushing_interval_deadline
@@ -121,10 +124,13 @@ module Optimizely
         item = @event_queue.pop if @event_queue.length.positive? || @use_pop
 
         if item.nil?
+          # when nil count is greater than MAX_NIL_COUNT, we hang on the pop until there is an item available.
+          # this avoids to much spinning of the loop.
           @nil_count += 1
           next
         end
 
+        # reset nil_count and use_pop if we have received an item.
         @nil_count = 0
         @use_pop = false
 

--- a/lib/optimizely/event/batch_event_processor.rb
+++ b/lib/optimizely/event/batch_event_processor.rb
@@ -119,7 +119,7 @@ module Optimizely
         item = @event_queue.pop if @event_queue.length.positive? || @nil_count > MAX_NIL_COUNT
 
         if item.nil?
-          interval = (@flushing_interval_deadline - Helpers::DateTimeUtils.create_timestamp) / 1000
+          interval = (@flushing_interval_deadline - Helpers::DateTimeUtils.create_timestamp) / 1000.0
           @logger.log(Logger::DEBUG, 'Sleeping for ' + interval.to_s)
           sleep(interval)
           @nil_count += 1

--- a/lib/optimizely/event/batch_event_processor.rb
+++ b/lib/optimizely/event/batch_event_processor.rb
@@ -113,10 +113,9 @@ module Optimizely
           @flushing_interval_deadline = Helpers::DateTimeUtils.create_timestamp + @flush_interval
         end
 
-        item = @event_queue.pop if @event_queue.length.positive?
+        item = @event_queue.pop
 
         if item.nil?
-          sleep(@flush_interval)
           next
         end
 

--- a/lib/optimizely/event/batch_event_processor.rb
+++ b/lib/optimizely/event/batch_event_processor.rb
@@ -110,7 +110,7 @@ module Optimizely
     def run
       @nil_count = 0
       loop do
-        if Helpers::DateTimeUtils.create_timestamp >= @flushing_interval_deadline  || @nil_count > MAX_NIL_COUNT
+        if Helpers::DateTimeUtils.create_timestamp >= @flushing_interval_deadline || @nil_count > MAX_NIL_COUNT
           @logger.log(Logger::DEBUG, 'Deadline exceeded flushing current batch.')
           flush_queue!
           @flushing_interval_deadline = Helpers::DateTimeUtils.create_timestamp + @flush_interval

--- a/lib/optimizely/event/batch_event_processor.rb
+++ b/lib/optimizely/event/batch_event_processor.rb
@@ -122,7 +122,7 @@ module Optimizely
         item = @event_queue.pop if @event_queue.length.positive? || @nil_count > MAX_NIL_COUNT
 
         if item.nil?
-          interval = @flushing_interval_deadline - Helpers::DateTimeUtils.create_timestamp
+          interval = (@flushing_interval_deadline - Helpers::DateTimeUtils.create_timestamp)/1000
           @logger.log(
               Logger::DEBUG,
               'Sleeping for ' + interval.to_s

--- a/lib/optimizely/event/batch_event_processor.rb
+++ b/lib/optimizely/event/batch_event_processor.rb
@@ -121,7 +121,6 @@ module Optimizely
         item = @event_queue.pop if @event_queue.length.positive? || @use_pop
 
         if item.nil?
-          sleep(0.5)
           @nil_count += 1
           next
         end

--- a/lib/optimizely/event/batch_event_processor.rb
+++ b/lib/optimizely/event/batch_event_processor.rb
@@ -107,7 +107,6 @@ module Optimizely
     private
 
     def run
-      @empty_count = 1
       loop do
         if Helpers::DateTimeUtils.create_timestamp > @flushing_interval_deadline
           flush_queue!
@@ -117,11 +116,8 @@ module Optimizely
         item = @event_queue.pop if @event_queue.length.positive?
 
         if item.nil?
-          sleep(0.05 * @empty_count)
-          @empty_count++
+          sleep(@flush_interval)
           next
-        else
-          @empty_count = 1
         end
 
         if item == SHUTDOWN_SIGNAL

--- a/lib/optimizely/event/batch_event_processor.rb
+++ b/lib/optimizely/event/batch_event_processor.rb
@@ -120,7 +120,7 @@ module Optimizely
         item = @event_queue.pop if @event_queue.length.positive? || @nil_count > MAX_NIL_COUNT
 
         if item.nil?
-          if @interval == 0
+          if @interval.zero?
             @interval = (@flushing_interval_deadline - Helpers::DateTimeUtils.create_timestamp) / 1000.0
             @interval /= MAX_NIL_COUNT
           end

--- a/lib/optimizely/event/batch_event_processor.rb
+++ b/lib/optimizely/event/batch_event_processor.rb
@@ -111,10 +111,7 @@ module Optimizely
       @nil_count = 0
       loop do
         if Helpers::DateTimeUtils.create_timestamp >= @flushing_interval_deadline
-          @logger.log(
-              Logger::DEBUG,
-              'Deadline exceeded flushing current batch.'
-          )
+          @logger.log(Logger::DEBUG, 'Deadline exceeded flushing current batch.')
           flush_queue!
           @flushing_interval_deadline = Helpers::DateTimeUtils.create_timestamp + @flush_interval
         end
@@ -122,11 +119,8 @@ module Optimizely
         item = @event_queue.pop if @event_queue.length.positive? || @nil_count > MAX_NIL_COUNT
 
         if item.nil?
-          interval = (@flushing_interval_deadline - Helpers::DateTimeUtils.create_timestamp)/1000
-          @logger.log(
-              Logger::DEBUG,
-              'Sleeping for ' + interval.to_s
-          )
+          interval = (@flushing_interval_deadline - Helpers::DateTimeUtils.create_timestamp) / 1000
+          @logger.log(Logger::DEBUG, 'Sleeping for ' + interval.to_s)
           sleep(interval)
           @nil_count += 1
           next

--- a/lib/optimizely/event_dispatcher.rb
+++ b/lib/optimizely/event_dispatcher.rb
@@ -59,6 +59,8 @@ module Optimizely
       when 500...600
         @logger.log(Logger::ERROR, error_msg)
         @error_handler.handle_error(HTTPCallError.new("HTTP Server Error: #{response.code}"))
+      else
+        @logger.log(Logger::DEBUG, 'event successfully sent with response code ' + response.code.to_s)
       end
     rescue Timeout::Error => e
       @logger.log(Logger::ERROR, "Request Timed out. Error: #{e}")

--- a/spec/event/batch_event_processor_spec.rb
+++ b/spec/event/batch_event_processor_spec.rb
@@ -62,7 +62,7 @@ describe Optimizely::BatchEventProcessor do
 
     @event_processor.process(conversion_event)
     # flush interval is set to 100ms. Wait for 300ms and assert that event is dispatched.
-    sleep 0.3
+    sleep 1
 
     expect(@event_dispatcher).to have_received(:dispatch_event).with(log_event).once
     expect(@notification_center).to have_received(:send_notifications).with(

--- a/spec/event/batch_event_processor_spec.rb
+++ b/spec/event/batch_event_processor_spec.rb
@@ -130,9 +130,9 @@ describe Optimizely::BatchEventProcessor do
 
   it 'should flush on mismatch revision' do
     @event_processor = Optimizely::BatchEventProcessor.new(
-        event_dispatcher: @event_dispatcher,
-        logger: spy_logger,
-        notification_center: @notification_center
+      event_dispatcher: @event_dispatcher,
+      logger: spy_logger,
+      notification_center: @notification_center
     )
 
     allow(project_config).to receive(:revision).and_return('1', '2')
@@ -157,9 +157,9 @@ describe Optimizely::BatchEventProcessor do
 
   it 'should flush on mismatch project id' do
     @event_processor = Optimizely::BatchEventProcessor.new(
-        event_dispatcher: @event_dispatcher,
-        logger: spy_logger,
-        notification_center: @notification_center
+      event_dispatcher: @event_dispatcher,
+      logger: spy_logger,
+      notification_center: @notification_center
     )
 
     allow(project_config).to receive(:project_id).and_return('X', 'Y')
@@ -182,7 +182,7 @@ describe Optimizely::BatchEventProcessor do
     expect(spy_logger).to have_received(:log).with(Logger::DEBUG, 'Project Ids mismatched: Flushing current batch.').once
     expect(spy_logger).not_to have_received(:log).with(Logger::DEBUG, 'Deadline exceeded flushing current batch.')
   end
-  
+
   it 'should set default batch size when provided invalid' do
     event_processor = Optimizely::BatchEventProcessor.new(event_dispatcher: @event_dispatcher)
     expect(event_processor.batch_size).to eq(10)
@@ -295,10 +295,10 @@ describe Optimizely::BatchEventProcessor do
 
   it 'should flush pending events when stop is called' do
     @event_processor = Optimizely::BatchEventProcessor.new(
-        event_dispatcher: @event_dispatcher,
-        batch_size: 5,
-        flush_interval: 10_000,
-        logger: spy_logger
+      event_dispatcher: @event_dispatcher,
+      batch_size: 5,
+      flush_interval: 10_000,
+      logger: spy_logger
     )
 
     experiment = project_config.get_experiment_from_key('test_experiment')
@@ -323,7 +323,7 @@ describe Optimizely::BatchEventProcessor do
     expect(spy_logger).to have_received(:log).with(Logger::INFO, 'Exiting processing loop. Attempting to flush pending events.')
     expect(spy_logger).not_to have_received(:log).with(Logger::DEBUG, 'Flushing on max batch size!')
     expect(@event_dispatcher).to have_received(:dispatch_event).with(
-        Optimizely::EventFactory.create_log_event(expected_batch, spy_logger)
+      Optimizely::EventFactory.create_log_event(expected_batch, spy_logger)
     )
   end
 

--- a/spec/event_dispatcher_spec.rb
+++ b/spec/event_dispatcher_spec.rb
@@ -146,9 +146,9 @@ describe Optimizely::EventDispatcher do
 
     response = @customized_event_dispatcher.dispatch_event(event)
 
-    expect(response).to be_nil
-    expect(spy_logger).not_to have_received(:log)
-    expect(error_handler).not_to have_received(:handle_error)
+    expect(response).to have_received(:log)
+    expect(spy_logger).to have_received(:log)
+    expect(error_handler).to_not have_received(:handle_error)
   end
 
   it 'should do nothing on response with status code 600' do
@@ -157,8 +157,8 @@ describe Optimizely::EventDispatcher do
 
     response = @customized_event_dispatcher.dispatch_event(event)
 
-    expect(response).to be_nil
-    expect(spy_logger).not_to have_received(:log)
+    expect(response).to have_received(:log)
+    expect(spy_logger).to have_received(:log)
     expect(error_handler).not_to have_received(:handle_error)
   end
 end


### PR DESCRIPTION
## Summary
- The loop ends up running too often and not paying attention to flush interval.

## Test plan
- Needs unit tests

## Issues
- Batch event processor ends up in a tight always running loop when there are no events.
