### PR TITLE
Should not be ignoring `rescue Exception` lint errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,8 +45,5 @@ Style/RescueStandardError:
 Style/SignalException:
   Enabled: false
 
-Lint/RescueException:
-  Enabled: false
-
 Layout/EndOfLine:
   EnforcedStyle: lf


### PR DESCRIPTION
It is almost always an error to be rescuing the base `Exception` class. See https://rubystyle.guide/#no-blind-rescues

"base" exceptions should be rescuing `StandardError`.

In cases where it truly is desired to rescue `Exception`, it should require the lint rule be explicitly disabled for that line, preferably with a comment explaining _why_. Disabling this rule by default is dangerous as it lets unintentional occurrences leak in. (as I believe has happened in this gem a number of times)