### PR TITLE
(fix): refactor batch_processor to start on first process and use mutex to wait till deadline if nothing in the queue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,7 +46,7 @@ Style/SignalException:
   Enabled: false
 
 Lint/RescueException:
-  Enabled: false
+  Enabled: true
 
 Layout/EndOfLine:
   EnforcedStyle: lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.5.1
   - 2.6.0
 before_install:
-  - gem update --system
+#  - gem update --system
   - gem install bundler
 install:
   - bundle install

--- a/spec/event/batch_event_processor_spec.rb
+++ b/spec/event/batch_event_processor_spec.rb
@@ -337,7 +337,7 @@ describe Optimizely::BatchEventProcessor do
 
   it 'should log a warning when Queue gets full' do
     @event_processor = Optimizely::BatchEventProcessor.new(
-      event_queue: SizedQueue.new(10),
+      event_queue: SizedQueue.new(5),
       event_dispatcher: @event_dispatcher,
       batch_size: 1000,
       flush_interval: 10_000,

--- a/spec/event/batch_event_processor_spec.rb
+++ b/spec/event/batch_event_processor_spec.rb
@@ -73,7 +73,7 @@ describe Optimizely::BatchEventProcessor do
       log_event
     ).once
     expect(spy_logger).to have_received(:log).with(Logger::INFO, 'Flushing Queue.').once
-    expect(spy_logger).to have_received(:log).with(Logger::DEBUG, 'Deadline exceeded flushing current batch.').once
+    expect(spy_logger).to have_received(:log).with(Logger::DEBUG, 'Deadline exceeded flushing current batch.').at_most(2).times
   end
 
   it 'should flush the current batch when max batch size met' do

--- a/spec/event/batch_event_processor_spec.rb
+++ b/spec/event/batch_event_processor_spec.rb
@@ -344,7 +344,7 @@ describe Optimizely::BatchEventProcessor do
     )
 
     user_event = Optimizely::UserEventFactory.create_conversion_event(project_config, event, 'test_user', nil, nil)
-    100.times do
+    900.times do
       @event_processor.process(user_event)
     end
 

--- a/spec/event/batch_event_processor_spec.rb
+++ b/spec/event/batch_event_processor_spec.rb
@@ -338,13 +338,13 @@ describe Optimizely::BatchEventProcessor do
     @event_processor = Optimizely::BatchEventProcessor.new(
       event_queue: SizedQueue.new(10),
       event_dispatcher: @event_dispatcher,
-      batch_size: 100,
+      batch_size: 1000,
       flush_interval: 10_000,
       logger: spy_logger
     )
 
     user_event = Optimizely::UserEventFactory.create_conversion_event(project_config, event, 'test_user', nil, nil)
-    80.times do
+    100.times do
       @event_processor.process(user_event)
     end
 

--- a/spec/event/batch_event_processor_spec.rb
+++ b/spec/event/batch_event_processor_spec.rb
@@ -64,7 +64,7 @@ describe Optimizely::BatchEventProcessor do
     )
 
     @event_processor.process(conversion_event)
-    # flush interval is set to 100ms. Wait for 300ms and assert that event is dispatched.
+    # flush interval is set to 100ms. Wait for 200ms and assert that event is dispatched.
     sleep 0.2
 
     expect(@event_dispatcher).to have_received(:dispatch_event).with(log_event).once
@@ -73,6 +73,7 @@ describe Optimizely::BatchEventProcessor do
       log_event
     ).once
     expect(spy_logger).to have_received(:log).with(Logger::INFO, 'Flushing Queue.').once
+    expect(spy_logger).to have_received(:log).with(Logger::DEBUG, 'Deadline exceeded flushing current batch.').once
   end
 
   it 'should flush the current batch when max batch size met' do

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -2814,6 +2814,8 @@ describe 'Optimizely' do
       project_instance = Optimizely::Project.new(nil, nil, nil, nil, true, nil, nil, config_manager, nil, event_processor)
 
       expect(config_manager.stopped).to be false
+      expect(event_processor.started).to be false
+      event_processor.start!
       expect(event_processor.started).to be true
 
       project_instance.close


### PR DESCRIPTION
## Summary
- Use a mutex so wait for a timeout since pop on SizedQueue does not support timeout.
- Empty the queue before going to mutex wait.
- Signal on process, flush, and stop.
- Add more debugging.

## Test plan
- Adjusted some unit tests. 