### PR TITLE
add spell check to markdown files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ jobs:
         email: false
     - stage: 'Lint markdown files'
       language: node_js
+      node_js: 12
       os: linux
       before_install: skip
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
       install:
         - npm i -g markdown-spellcheck
       before_script:
-        - wget https://gist.githubusercontent.com/juancarlostong/dad02feeebc8763af35b4fdc717cf7a2/raw/29e085302a9418edbefba15d8f790fa76e0a89d5/.spelling
+        - wget --quiet https://gist.githubusercontent.com/juancarlostong/dad02feeebc8763af35b4fdc717cf7a2/raw/29e085302a9418edbefba15d8f790fa76e0a89d5/.spelling
       script:
         - mdspell -a -n -r --en-us '**/*.md'
       after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,17 @@ jobs:
         - find . -type f -name '*.md' -exec awesome_bot {} \;
       notifications:
         email: false
+    - stage: 'Lint markdown files'
+      language: node_js
+      os: linux
+      before_install: skip
+      install:
+        - npm i -g markdown-spellcheck
+      before_script:
+        - wget https://gist.githubusercontent.com/juancarlostong/dad02feeebc8763af35b4fdc717cf7a2/raw/29e085302a9418edbefba15d8f790fa76e0a89d5/.spelling
+      script:
+        - mdspell -a -n -r --en-us '**/*.md'
+      after_success: skip
  
     - &integrationtest
       stage: 'Integration tests'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ January 23rd, 2020
   - Call `get_optimizely_config` to get a snapshot copy of project configuration static data.
   - It returns an `OptimizelyConfig` instance which includes a datafile revision number, all experiments, and feature flags mapped by their key values.
   - Added caching for `get_optimizely_config` - `OptimizelyConfig` object will be cached and reused for the lifetime of the datafile
-  - For details, refer to a documention page: https://docs.developers.optimizely.com/full-stack/docs/optimizelyconfig-ruby
+  - For details, refer to a documentation page: https://docs.developers.optimizely.com/full-stack/docs/optimizelyconfig-ruby
 
 
 ## 3.3.2

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can initialize the Optimizely instance in two ways: directly with a datafile
 
 #### Initialization by OptimizelyFactory
 
- 1. Initialize Optimizely by providing an `sdk_key` and an optional `datafile`. This will initialize an HTTPConfigManager that makes an HTTP GET request to the URL (formed using your provided `sdk_key` and the default datafile CDN url template) to asynchronously download the project datafile at regular intervals and update ProjectConfig when a new datafile is recieved.
+ 1. Initialize Optimizely by providing an `sdk_key` and an optional `datafile`. This will initialize an HTTPConfigManager that makes an HTTP GET request to the URL (formed using your provided `sdk_key` and the default datafile CDN url template) to asynchronously download the project datafile at regular intervals and update ProjectConfig when a new datafile is received.
 
     ```
     optimizely_instance = Optimizely::OptimizelyFactory.default_instance('put_your_sdk_key_here', datafile)


### PR DESCRIPTION
## Summary
- Adds spellchecker to *.md

This is what it looks like when it finds a spelling error (aborts build):
https://travis-ci.org/optimizely/ruby-sdk/jobs/647067279
