### PR TITLE
fix: errors being raised without required args

### DIFF
--- a/lib/optimizely/config/datafile_project_config.rb
+++ b/lib/optimizely/config/datafile_project_config.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#    Copyright 2019, Optimizely and contributors
+#    Copyright 2019-2020, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -159,8 +159,9 @@ module Optimizely
         config = new(datafile, logger, error_handler)
       rescue StandardError => e
         default_logger = SimpleLogger.new
-        error_msg = e.class == InvalidDatafileVersionError ? e.message : InvalidInputError.new('datafile').message
-        error_to_handle = e.class == InvalidDatafileVersionError ? InvalidDatafileVersionError : InvalidInputError
+        error_to_handle = e.class == InvalidDatafileVersionError ? e : InvalidInputError.new('datafile')
+        error_msg = error_to_handle.message
+
         default_logger.log(Logger::ERROR, error_msg)
         error_handler.handle_error error_to_handle
         return nil

--- a/lib/optimizely/config_manager/http_project_config_manager.rb
+++ b/lib/optimizely/config_manager/http_project_config_manager.rb
@@ -284,8 +284,9 @@ module Optimizely
       #               SDK key to determine URL from which to fetch the datafile.
       # Returns String representing URL to fetch datafile from.
       if sdk_key.nil? && url.nil?
-        @logger.log(Logger::ERROR, 'Must provide at least one of sdk_key or url.')
-        @error_handler.handle_error(InvalidInputsError)
+        error_msg = 'Must provide at least one of sdk_key or url.'
+        @logger.log(Logger::ERROR, error_msg)
+        @error_handler.handle_error(InvalidInputsError.new(error_msg))
       end
 
       unless url
@@ -293,8 +294,9 @@ module Optimizely
         begin
           return (url_template % sdk_key)
         rescue
-          @logger.log(Logger::ERROR, "Invalid url_template #{url_template} provided.")
-          @error_handler.handle_error(InvalidInputsError)
+          error_msg = "Invalid url_template #{url_template} provided."
+          @logger.log(Logger::ERROR, error_msg)
+          @error_handler.handle_error(InvalidInputsError.new(error_msg))
         end
       end
 

--- a/lib/optimizely/exceptions.rb
+++ b/lib/optimizely/exceptions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2019, Optimizely and contributors
+#    Copyright 2016-2020, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -78,14 +78,6 @@ module Optimizely
 
     def initialize(msg = 'Provided variation is not in datafile.')
       super
-    end
-  end
-
-  class InvalidDatafileError < Error
-    # Raised when a public method fails due to an invalid datafile
-
-    def initialize(aborted_method)
-      super("Provided datafile is in an invalid format. Aborting #{aborted_method}.")
     end
   end
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2019, Optimizely and contributors
+#    Copyright 2016-2020, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -130,9 +130,8 @@ describe 'Optimizely' do
     it 'should log and raise an error when provided a datafile of unsupported version' do
       config_body_invalid_json = JSON.parse(config_body_invalid_JSON)
       expect_any_instance_of(Optimizely::SimpleLogger).to receive(:log).once.with(Logger::ERROR, "This version of the Ruby SDK does not support the given datafile version: #{config_body_invalid_json['version']}.")
-      expect_any_instance_of(Optimizely::RaiseErrorHandler).to receive(:handle_error).once.with(Optimizely::InvalidDatafileVersionError)
 
-      Optimizely::Project.new(config_body_invalid_JSON, nil, nil, Optimizely::RaiseErrorHandler.new, true)
+      expect { Optimizely::Project.new(config_body_invalid_JSON, nil, nil, Optimizely::RaiseErrorHandler.new, true) }.to raise_error(Optimizely::InvalidDatafileVersionError, 'This version of the Ruby SDK does not support the given datafile version: 5.')
     end
   end
 


### PR DESCRIPTION
## Summary
Some of the errors being throw without the required msg argument to initialize that error type. Expecting handle_error method inside unit tests doesn't initialize the error instance. This PR modifies the raise error assertion inside unit tests and fixes where required. 
Also removes an unused error type. 

## Test plan
All tests continue to pass. 

## Issues
