### PR TITLE
refact: Replace httparty in favor of core net/http package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Gemfile.lock
 /tmp/
 *.DS_Store
 .ruby-version
+vendor/bundle

--- a/lib/optimizely/config_manager/http_project_config_manager.rb
+++ b/lib/optimizely/config_manager/http_project_config_manager.rb
@@ -19,7 +19,7 @@ require_relative '../config/datafile_project_config'
 require_relative '../error_handler'
 require_relative '../exceptions'
 require_relative '../helpers/constants'
-require_relative '../helpers/network_utils'
+require_relative '../helpers/http_utils'
 require_relative '../logger'
 require_relative '../notification_center'
 require_relative '../project_config'
@@ -154,7 +154,7 @@ module Optimizely
         headers['Content-Type'] = 'application/json'
         headers['If-Modified-Since'] = @last_modified if @last_modified
 
-        response = Helpers::NetworkUtils.make_request(
+        response = Helpers::HttpUtils.make_request(
           @datafile_url, :get, nil, headers, Helpers::Constants::CONFIG_MANAGER['REQUEST_TIMEOUT']
         )
       rescue StandardError => e

--- a/lib/optimizely/event_dispatcher.rb
+++ b/lib/optimizely/event_dispatcher.rb
@@ -16,7 +16,7 @@
 #    limitations under the License.
 #
 require_relative 'exceptions'
-require_relative 'helpers/network_utils'
+require_relative 'helpers/http_utils'
 
 module Optimizely
   class NoOpEventDispatcher
@@ -38,7 +38,7 @@ module Optimizely
     #
     # @param event - Event object
     def dispatch_event(event)
-      response = Helpers::NetworkUtils.make_request(
+      response = Helpers::HttpUtils.make_request(
         event.url, event.http_verb, event.params.to_json, event.headers, REQUEST_TIMEOUT
       )
 

--- a/lib/optimizely/helpers/http_utils.rb
+++ b/lib/optimizely/helpers/http_utils.rb
@@ -20,7 +20,7 @@ require 'net/http'
 
 module Optimizely
   module Helpers
-    module NetworkUtils
+    module HttpUtils
       module_function
 
       def make_request(url, http_method, request_body = nil, headers = {}, read_timeout = nil)

--- a/lib/optimizely/helpers/network_utils.rb
+++ b/lib/optimizely/helpers/network_utils.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#
+#    Copyright 2020, Optimizely and contributors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'net/http'
+
+module Optimizely
+  module Helpers
+    module NetworkUtils
+      module_function
+
+      def make_request(url, http_method, request_body = nil, headers = {}, read_timeout = nil)
+        # makes http/https GET/POST request and returns response
+
+        uri = URI.parse(url)
+        http = Net::HTTP.new(uri.host, uri.port)
+
+        http.read_timeout = read_timeout if read_timeout
+        http.use_ssl = uri.scheme == 'https'
+
+        if http_method == :get
+          request = Net::HTTP::Get.new(uri.request_uri)
+        elsif http_method == :post
+          request = Net::HTTP::Post.new(uri.request_uri)
+          request.body = request_body if request_body
+        else
+          return nil
+        end
+
+        # set headers
+        headers&.each do |key, val|
+          request[key] = val
+        end
+
+        http.request(request)
+      end
+    end
+  end
+end

--- a/optimizely-sdk.gemspec
+++ b/optimizely-sdk.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '0.73.0'
   spec.add_development_dependency 'webmock'
 
-  spec.add_runtime_dependency 'httparty', '~> 0.11'
   spec.add_runtime_dependency 'json-schema', '~> 2.6'
   spec.add_runtime_dependency 'murmurhash3', '~> 0.1'
 end

--- a/spec/config_manager/http_project_config_manager_spec.rb
+++ b/spec/config_manager/http_project_config_manager_spec.rb
@@ -69,6 +69,24 @@ describe Optimizely::HTTPProjectConfigManager do
       expect(@http_project_config_manager.config).to be_a Optimizely::ProjectConfig
     end
 
+    it 'should get project config when valid http url is given' do
+      WebMock.reset!
+      stub_request(:get, 'http://cdn.optimizely.com/datafiles/valid_sdk_key.json')
+        .with(
+          headers: {
+            'Content-Type' => 'application/json'
+          }
+        )
+        .to_return(status: 200, body: VALID_SDK_KEY_CONFIG_JSON, headers: {})
+
+      @http_project_config_manager = Optimizely::HTTPProjectConfigManager.new(
+        url: 'http://cdn.optimizely.com/datafiles/valid_sdk_key.json'
+      )
+
+      until @http_project_config_manager.ready?; end
+      expect(@http_project_config_manager.config).to be_a Optimizely::ProjectConfig
+    end
+
     it 'should get project config when sdk_key is given' do
       @http_project_config_manager = Optimizely::HTTPProjectConfigManager.new(
         sdk_key: 'valid_sdk_key'

--- a/spec/event_dispatcher_spec.rb
+++ b/spec/event_dispatcher_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2017, 2019, Optimizely and contributors
+#    Copyright 2016-2017, 2019-2020 Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -47,6 +47,16 @@ describe Optimizely::EventDispatcher do
     @event_dispatcher.dispatch_event(event)
 
     expect(a_request(:post, @url)
+      .with(body: @params, headers: @post_headers)).to have_been_made.once
+  end
+
+  it 'should properly dispatch V2 (POST) events to http url' do
+    http_url = 'http://www.optimizely.com'
+    stub_request(:post, http_url)
+    event = Optimizely::Event.new(:post, http_url, @params, @post_headers)
+    @event_dispatcher.dispatch_event(event)
+
+    expect(a_request(:post, http_url)
       .with(body: @params, headers: @post_headers)).to have_been_made.once
   end
 

--- a/spec/event_dispatcher_spec.rb
+++ b/spec/event_dispatcher_spec.rb
@@ -51,10 +51,9 @@ describe Optimizely::EventDispatcher do
   end
 
   it 'should properly dispatch V2 (POST) events with timeout exception' do
-    stub_request(:post, @url)
     event = Optimizely::Event.new(:post, @url, @params, @post_headers)
     timeout_error = Timeout::Error.new
-    allow(HTTParty).to receive(:post).with(any_args).and_raise(timeout_error)
+    stub_request(:post, @url).to_raise(timeout_error)
     result = @event_dispatcher.dispatch_event(event)
 
     expect(result).to eq(timeout_error)
@@ -71,10 +70,10 @@ describe Optimizely::EventDispatcher do
 
   it 'should properly dispatch V2 (GET) events with timeout exception' do
     get_url = @url + '?a=111001&g=111028&n=test_event&u=test_user'
-    stub_request(:get, get_url)
     event = Optimizely::Event.new(:get, get_url, @params, @post_headers)
     timeout_error = Timeout::Error.new
-    allow(HTTParty).to receive(:get).with(any_args).and_raise(timeout_error)
+    stub_request(:get, get_url).to_raise(timeout_error)
+
     result = @event_dispatcher.dispatch_event(event)
 
     expect(result).to eq(timeout_error)
@@ -82,10 +81,10 @@ describe Optimizely::EventDispatcher do
 
   it 'should log and handle Timeout error' do
     get_url = @url + '?a=111001&g=111028&n=test_event&u=test_user'
-    stub_request(:post, get_url)
     event = Optimizely::Event.new(:post, get_url, @params, @post_headers)
     timeout_error = Timeout::Error.new
-    allow(HTTParty).to receive(:post).with(any_args).and_raise(timeout_error)
+    stub_request(:post, get_url).to_raise(timeout_error)
+
     result = @customized_event_dispatcher.dispatch_event(event)
 
     expect(result).to eq(timeout_error)
@@ -98,10 +97,9 @@ describe Optimizely::EventDispatcher do
 
   it 'should log and handle any standard error' do
     get_url = @url + '?a=111001&g=111028&n=test_event&u=test_user'
-    stub_request(:post, get_url)
     event = Optimizely::Event.new(:post, get_url, @params, @post_headers)
-    error = ArgumentError
-    allow(HTTParty).to receive(:post).with(any_args).and_raise(error)
+    stub_request(:post, get_url).to_raise(ArgumentError.new)
+
     result = @customized_event_dispatcher.dispatch_event(event)
 
     expect(result).to eq(nil)


### PR DESCRIPTION
## Summary
A request was made to minimize library dependencies from the SDK. HTTParty was being used at a minimal level only for fetching datafile and dispatching events. This PR replaces HTTParty by core ruby net/http package

## Test plan
All tests continue to pass. 

## Issues
https://github.com/optimizely/ruby-sdk/issues/211
OASIS-6453
