### PR TITLE
 fix(log-level) change single audience result to debug 

### DIFF
--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2017, 2019-2020 Optimizely and contributors
+#    Copyright 2016-2017, 2019-2020, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2017, 2019, Optimizely and contributors
+#    Copyright 2016-2017, 2019-2020 Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ module Optimizely
         result = ConditionTreeEvaluator.evaluate(audience_conditions, evaluate_custom_attr)
         result_str = result.nil? ? 'UNKNOWN' : result.to_s.upcase
         logger.log(
-          Logger::INFO,
+          Logger::DEBUG,
           format(Helpers::Constants::AUDIENCE_EVALUATION_LOGS['AUDIENCE_EVALUATION_RESULT'], audience_id, result_str)
         )
         result

--- a/spec/audience_spec.rb
+++ b/spec/audience_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2017, 2019-2020 Optimizely and contributors
+#    Copyright 2016-2017, 2019-2020, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/audience_spec.rb
+++ b/spec/audience_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2017, 2019, Optimizely and contributors
+#    Copyright 2016-2017, 2019-2020 Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -253,7 +253,7 @@ describe Optimizely::Audience do
     )
 
     expect(spy_logger).to have_received(:log).once.with(
-      Logger::INFO,
+      Logger::DEBUG,
       "Audience '11154' evaluated to UNKNOWN."
     )
 
@@ -265,7 +265,7 @@ describe Optimizely::Audience do
     )
 
     expect(spy_logger).to have_received(:log).once.with(
-      Logger::INFO,
+      Logger::DEBUG,
       "Audience '11155' evaluated to UNKNOWN."
     )
 
@@ -299,7 +299,7 @@ describe Optimizely::Audience do
     ).ordered # Order: 1
 
     expect(spy_logger).to have_received(:log).once.with(
-      Logger::INFO,
+      Logger::DEBUG,
       "Audience '3468206647' evaluated to FALSE."
     ).ordered # Order: 2
 
@@ -311,7 +311,7 @@ describe Optimizely::Audience do
     ).ordered # Order: 3
 
     expect(spy_logger).to have_received(:log).once.with(
-      Logger::INFO,
+      Logger::DEBUG,
       "Audience '3988293898' evaluated to UNKNOWN."
     ).ordered # Order: 4
 
@@ -323,7 +323,7 @@ describe Optimizely::Audience do
     ).ordered # Order: 5
 
     expect(spy_logger).to have_received(:log).once.with(
-      Logger::INFO,
+      Logger::DEBUG,
       "Audience '3468206646' evaluated to TRUE."
     ).ordered # Order: 6
 


### PR DESCRIPTION
## Summary
Modifying log level for single audience evaluation from INFO to DEBUG to reduce noise in logs. Now, only combined audience evaluation is logged at INFO level.

## Test plan
All checks pass.

## Issues
- OASIS-6521
