### PR TITLE
fix(logs): Fixing log messages

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -810,7 +810,7 @@ module Optimizely
           end
         else
           @logger.log(Logger::DEBUG,
-                      "Feature '#{feature_flag_key}' for variation '#{variation['key']}' is not enabled. Returning the default variable value '#{variable_value}'.")
+                      "Feature '#{feature_flag_key}' is not enabled for user '#{user_id}'. Returning the default variable value '#{variable_value}'.")
         end
       else
         @logger.log(Logger::INFO,

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -806,7 +806,8 @@ module Optimizely
                         "Got variable value '#{variable_value}' for variable '#{variable['key']}' of feature flag '#{feature_flag_key}'.")
           else
             @logger.log(Logger::DEBUG,
-                        "Variable '#{variable['key']}' is not used in variation '#{variation['key']}'. Returning the default variable value '#{variable_value}'.")
+                        "Variable value is not defined. Returning the default variable value '#{variable_value}' for variable '#{variable['key']}'.")
+
           end
         else
           @logger.log(Logger::DEBUG,
@@ -814,7 +815,7 @@ module Optimizely
         end
       else
         @logger.log(Logger::INFO,
-                    "User '#{user_id}' was not bucketed into any variation for feature flag '#{feature_flag_key}'. Returning the default variable value '#{variable_value}'.")
+                    "User '#{user_id}' was not bucketed into experiment or rollout for feature flag '#{feature_flag_key}'. Returning the default variable value '#{variable_value}'.")
       end
       variable_value
     end

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -25,10 +25,10 @@ module Optimizely
     module_function
 
     def user_meets_audience_conditions?(config, experiment, attributes, logger, logging_hash = nil, logging_key = nil)
-      # Determine for given experiment/rollout rule if user satisfies the audiences.
+      # Determine for given experiment/rollout rule if user satisfies the audience conditions.
       #
       # config - Representation of the Optimizely project config.
-      # experiment - Experiment/Rollout rule for which visitor is to be bucketed.
+      # experiment - Experiment/Rollout rule in which user is to be bucketed.
       # attributes - Hash representing user attributes which will be used in determining if
       #              the audience conditions are met.
       # logger - Provides a logger instance.

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -24,7 +24,7 @@ module Optimizely
   module Audience
     module_function
 
-    def user_in_experiment?(config, experiment, attributes, logger)
+    def user_meets_audience_conditions?(config, experiment, attributes, logger)
       # Determine for given experiment if user satisfies the audiences for the experiment.
       #
       # config - Representation of the Optimizely project config.

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -24,7 +24,7 @@ module Optimizely
   module Audience
     module_function
 
-    def user_meets_audience_conditions?(config, experiment, attributes, logger)
+    def user_meets_audience_conditions?(config, experiment, attributes, logger, logging_hash = nil, logging_key = nil)
       # Determine for given experiment if user satisfies the audiences for the experiment.
       #
       # config - Representation of the Optimizely project config.
@@ -33,17 +33,18 @@ module Optimizely
       #              the audience conditions are met.
       #
       # Returns boolean representing if user satisfies audience conditions for the audiences or not.
+      logging_hash ||= 'EXPERIMENT_AUDIENCE_EVALUATION_LOGS'
+      logging_key ||= experiment['key']
+
+      logs_hash = Object.const_get "Optimizely::Helpers::Constants::#{logging_hash}"
 
       audience_conditions = experiment['audienceConditions'] || experiment['audienceIds']
-
-      eval_audience_combined_log = Helpers::Constants::AUDIENCE_EVALUATION_LOGS['EVALUATING_EXPERIMENT_COMBINED']
-      audience_result_combined_log = Helpers::Constants::AUDIENCE_EVALUATION_LOGS['EXPERIMENT_RESULT_COMBINED']
 
       logger.log(
         Logger::DEBUG,
         format(
-          eval_audience_combined_log,
-          experiment['key'],
+          logs_hash['EVALUATING_AUDIENCES_COMBINED'],
+          logging_key,
           audience_conditions
         )
       )
@@ -53,8 +54,8 @@ module Optimizely
         logger.log(
           Logger::INFO,
           format(
-            audience_result_combined_log,
-            experiment['key'],
+            logs_hash['AUDIENCE_EVALUATION_RESULT_COMBINED'],
+            logging_key,
             'TRUE'
           )
         )
@@ -77,7 +78,7 @@ module Optimizely
         logger.log(
           Logger::DEBUG,
           format(
-            Helpers::Constants::AUDIENCE_EVALUATION_LOGS['EVALUATING_AUDIENCE'],
+            logs_hash['EVALUATING_AUDIENCE'],
             audience_id,
             audience_conditions
           )
@@ -88,7 +89,7 @@ module Optimizely
         result_str = result.nil? ? 'UNKNOWN' : result.to_s.upcase
         logger.log(
           Logger::DEBUG,
-          format(Helpers::Constants::AUDIENCE_EVALUATION_LOGS['AUDIENCE_EVALUATION_RESULT'], audience_id, result_str)
+          format(logs_hash['AUDIENCE_EVALUATION_RESULT'], audience_id, result_str)
         )
         result
       end
@@ -100,8 +101,8 @@ module Optimizely
       logger.log(
         Logger::INFO,
         format(
-          audience_result_combined_log,
-          experiment['key'],
+          logs_hash['AUDIENCE_EVALUATION_RESULT_COMBINED'],
+          logging_key,
           eval_result.to_s.upcase
         )
       )

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -25,10 +25,10 @@ module Optimizely
     module_function
 
     def user_meets_audience_conditions?(config, experiment, attributes, logger, logging_hash = nil, logging_key = nil)
-      # Determine for given experiment if user satisfies the audiences for the experiment.
+      # Determine for given experiment/rollout rule if user satisfies the audiences.
       #
       # config - Representation of the Optimizely project config.
-      # experiment - Experiment for which visitor is to be bucketed.
+      # experiment - Experiment/Rollout rule for which visitor is to be bucketed.
       # attributes - Hash representing user attributes which will be used in determining if
       #              the audience conditions are met.
       # logger - Provides a logger instance.

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -36,10 +36,13 @@ module Optimizely
 
       audience_conditions = experiment['audienceConditions'] || experiment['audienceIds']
 
+      eval_audience_combined_log = Helpers::Constants::AUDIENCE_EVALUATION_LOGS['EVALUATING_EXPERIMENT_COMBINED']
+      audience_result_combined_log = Helpers::Constants::AUDIENCE_EVALUATION_LOGS['EXPERIMENT_RESULT_COMBINED']
+
       logger.log(
         Logger::DEBUG,
         format(
-          Helpers::Constants::AUDIENCE_EVALUATION_LOGS['EVALUATING_AUDIENCES_COMBINED'],
+          eval_audience_combined_log,
           experiment['key'],
           audience_conditions
         )
@@ -50,7 +53,7 @@ module Optimizely
         logger.log(
           Logger::INFO,
           format(
-            Helpers::Constants::AUDIENCE_EVALUATION_LOGS['AUDIENCE_EVALUATION_RESULT_COMBINED'],
+            audience_result_combined_log,
             experiment['key'],
             'TRUE'
           )
@@ -97,7 +100,7 @@ module Optimizely
       logger.log(
         Logger::INFO,
         format(
-          Helpers::Constants::AUDIENCE_EVALUATION_LOGS['AUDIENCE_EVALUATION_RESULT_COMBINED'],
+          audience_result_combined_log,
           experiment['key'],
           eval_result.to_s.upcase
         )

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -31,6 +31,11 @@ module Optimizely
       # experiment - Experiment for which visitor is to be bucketed.
       # attributes - Hash representing user attributes which will be used in determining if
       #              the audience conditions are met.
+      # logger - Provides a logger instance.
+      # logging_hash - Optional string representing logs hash inside Helpers::Constants.
+      #                This defaults to 'EXPERIMENT_AUDIENCE_EVALUATION_LOGS'.
+      # logging_key - Optional string to be logged as an identifier of experiment under evaluation.
+      #               This defaults to experiment['key'].
       #
       # Returns boolean representing if user satisfies audience conditions for the audiences or not.
       logging_hash ||= 'EXPERIMENT_AUDIENCE_EVALUATION_LOGS'

--- a/lib/optimizely/bucketer.rb
+++ b/lib/optimizely/bucketer.rb
@@ -39,7 +39,7 @@ module Optimizely
       # Determines ID of variation to be shown for a given experiment key and user ID.
       #
       # project_config - Instance of ProjectConfig
-      # experiment - Experiment for which visitor is to be bucketed.
+      # experiment - Experiment or Rollout rule for which visitor is to be bucketed.
       # bucketing_id - String A customer-assigned value used to generate the bucketing key
       # user_id - String ID for user.
       #
@@ -47,6 +47,7 @@ module Optimizely
       return nil if experiment.nil?
 
       # check if experiment is in a group; if so, check if user is bucketed into specified experiment
+      # this will not affect evaluation of rollout rules.
       experiment_id = experiment['id']
       experiment_key = experiment['key']
       group_id = experiment['groupId']
@@ -82,11 +83,6 @@ module Optimizely
       variation_id = find_bucket(bucketing_id, user_id, experiment_id, traffic_allocations)
       if variation_id && variation_id != ''
         variation = project_config.get_variation_from_id(experiment_key, variation_id)
-        variation_key = variation ? variation['key'] : nil
-        @logger.log(
-          Logger::INFO,
-          "User '#{user_id}' is in variation '#{variation_key}' of experiment '#{experiment_key}'."
-        )
         return variation
       end
 
@@ -98,7 +94,6 @@ module Optimizely
         )
       end
 
-      @logger.log(Logger::INFO, "User '#{user_id}' is in no variation.")
       nil
     end
 

--- a/lib/optimizely/bucketer.rb
+++ b/lib/optimizely/bucketer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2017, 2019 Optimizely and contributors
+#    Copyright 2016-2017, 2019-2020 Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -94,7 +94,7 @@ module Optimizely
       end
 
       # Check audience conditions
-      unless Audience.user_in_experiment?(project_config, experiment, attributes, @logger)
+      unless Audience.user_meets_audience_conditions?(project_config, experiment, attributes, @logger)
         @logger.log(
           Logger::INFO,
           "User '#{user_id}' does not meet the conditions to be in experiment '#{experiment_key}'."
@@ -246,7 +246,7 @@ module Optimizely
         audience_name = audience['name']
 
         # Check that user meets audience conditions for targeting rule
-        unless Audience.user_in_experiment?(project_config, rollout_rule, attributes, @logger)
+        unless Audience.user_meets_audience_conditions?(project_config, rollout_rule, attributes, @logger)
           @logger.log(
             Logger::DEBUG,
             "User '#{user_id}' does not meet the conditions to be in rollout rule for audience '#{audience_name}'."
@@ -265,7 +265,7 @@ module Optimizely
       # get last rule which is the everyone else rule
       everyone_else_experiment = rollout_rules[number_of_rules]
       # Check that user meets audience conditions for last rule
-      unless Audience.user_in_experiment?(project_config, everyone_else_experiment, attributes, @logger)
+      unless Audience.user_meets_audience_conditions?(project_config, everyone_else_experiment, attributes, @logger)
         audience_id = everyone_else_experiment['audienceIds'][0]
         audience = project_config.get_audience_from_id(audience_id)
         audience_name = audience['name']

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2017-2019, Optimizely and contributors
+#    Copyright 2017-2020, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -137,19 +137,8 @@ module Optimizely
 
       feature_flag_key = feature_flag['key']
       decision = get_variation_for_feature_rollout(project_config, feature_flag, user_id, attributes)
-      if decision
-        @logger.log(
-          Logger::INFO,
-          "User '#{user_id}' is bucketed into a rollout for feature flag '#{feature_flag_key}'."
-        )
-        return decision
-      end
-      @logger.log(
-        Logger::INFO,
-        "User '#{user_id}' is not bucketed into a rollout for feature flag '#{feature_flag_key}'."
-      )
-
-      nil
+      
+      decision
     end
 
     def get_variation_for_feature_experiment(project_config, feature_flag, user_id, attributes = nil)

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -106,6 +106,16 @@ module Optimizely
       variation = @bucketer.bucket(project_config, experiment, bucketing_id, user_id)
       variation_id = variation ? variation['id'] : nil
 
+      if variation_id
+        variation_key = variation['key']
+        @logger.log(
+          Logger::INFO,
+          "User '#{user_id}' is in variation '#{variation_key}' of experiment '#{experiment_key}'."
+        )
+      else
+        @logger.log(Logger::INFO, "User '#{user_id}' is in no variation.")
+      end
+
       # Persist bucketing decision
       save_user_profile(user_profile, experiment_id, variation_id)
       variation_id

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -246,7 +246,7 @@ module Optimizely
         audience_name = audience['name']
 
         # Check that user meets audience conditions for targeting rule
-        unless Audience.user_meets_audience_conditions?(project_config, rollout_rule, attributes, @logger)
+        unless Audience.user_meets_audience_conditions?(project_config, rollout_rule, attributes, @logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', index + 1)
           @logger.log(
             Logger::DEBUG,
             "User '#{user_id}' does not meet the conditions to be in rollout rule for audience '#{audience_name}'."
@@ -265,7 +265,7 @@ module Optimizely
       # get last rule which is the everyone else rule
       everyone_else_experiment = rollout_rules[number_of_rules]
       # Check that user meets audience conditions for last rule
-      unless Audience.user_meets_audience_conditions?(project_config, everyone_else_experiment, attributes, @logger)
+      unless Audience.user_meets_audience_conditions?(project_config, everyone_else_experiment, attributes, @logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 'Everyone Else')
         audience_id = everyone_else_experiment['audienceIds'][0]
         audience = project_config.get_audience_from_id(audience_id)
         audience_name = audience['name']

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -135,9 +135,8 @@ module Optimizely
       decision = get_variation_for_feature_experiment(project_config, feature_flag, user_id, attributes)
       return decision unless decision.nil?
 
-      feature_flag_key = feature_flag['key']
       decision = get_variation_for_feature_rollout(project_config, feature_flag, user_id, attributes)
-      
+
       decision
     end
 
@@ -177,10 +176,7 @@ module Optimizely
         next unless variation_id
 
         variation = project_config.variation_id_map[experiment_key][variation_id]
-        @logger.log(
-          Logger::INFO,
-          "The user '#{user_id}' is bucketed into experiment '#{experiment_key}' of feature '#{feature_flag_key}'."
-        )
+
         return Decision.new(experiment, variation, DECISION_SOURCES['FEATURE_TEST'])
       end
 

--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -335,9 +335,11 @@ module Optimizely
 
       AUDIENCE_EVALUATION_LOGS = {
         'AUDIENCE_EVALUATION_RESULT' => "Audience '%s' evaluated to %s.",
-        'AUDIENCE_EVALUATION_RESULT_COMBINED' => "Audiences for experiment '%s' collectively evaluated to %s.",
+        'EXPERIMENT_RESULT_COMBINED' => "Audiences for experiment '%s' collectively evaluated to %s.",
+        'ROLLOUT__RESULT_COMBINED' => "Audiences for rule '%s' collectively evaluated to %s.",
         'EVALUATING_AUDIENCE' => "Starting to evaluate audience '%s' with conditions: %s.",
-        'EVALUATING_AUDIENCES_COMBINED' => "Evaluating audiences for experiment '%s': %s.",
+        'EVALUATING_EXPERIMENT_COMBINED' => "Evaluating audiences for experiment '%s': %s.",
+        'EVALUATING_ROLLOUT_COMBINED' => "Evaluating audiences for rule '%s': %s.",
         'INFINITE_ATTRIBUTE_VALUE' => 'Audience condition %s evaluated to UNKNOWN because the number value ' \
         "for user attribute '%s' is not in the range [-2^53, +2^53].",
         'MISSING_ATTRIBUTE_VALUE' => 'Audience condition %s evaluated as UNKNOWN because no value ' \

--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -335,11 +335,7 @@ module Optimizely
 
       AUDIENCE_EVALUATION_LOGS = {
         'AUDIENCE_EVALUATION_RESULT' => "Audience '%s' evaluated to %s.",
-        'EXPERIMENT_RESULT_COMBINED' => "Audiences for experiment '%s' collectively evaluated to %s.",
-        'ROLLOUT__RESULT_COMBINED' => "Audiences for rule '%s' collectively evaluated to %s.",
         'EVALUATING_AUDIENCE' => "Starting to evaluate audience '%s' with conditions: %s.",
-        'EVALUATING_EXPERIMENT_COMBINED' => "Evaluating audiences for experiment '%s': %s.",
-        'EVALUATING_ROLLOUT_COMBINED' => "Evaluating audiences for rule '%s': %s.",
         'INFINITE_ATTRIBUTE_VALUE' => 'Audience condition %s evaluated to UNKNOWN because the number value ' \
         "for user attribute '%s' is not in the range [-2^53, +2^53].",
         'MISSING_ATTRIBUTE_VALUE' => 'Audience condition %s evaluated as UNKNOWN because no value ' \
@@ -355,6 +351,16 @@ module Optimizely
         'UNKNOWN_MATCH_TYPE' => 'Audience condition %s uses an unknown match type. You may need ' \
         'to upgrade to a newer release of the Optimizely SDK.'
       }.freeze
+
+      EXPERIMENT_AUDIENCE_EVALUATION_LOGS = {
+        'AUDIENCE_EVALUATION_RESULT_COMBINED' => "Audiences for experiment '%s' collectively evaluated to %s.",
+        'EVALUATING_AUDIENCES_COMBINED' => "Evaluating audiences for experiment '%s': %s."
+      }.merge(AUDIENCE_EVALUATION_LOGS).freeze
+
+      ROLLOUT_AUDIENCE_EVALUATION_LOGS = {
+        'AUDIENCE_EVALUATION_RESULT_COMBINED' => "Audiences for rule '%s' collectively evaluated to %s.",
+        'EVALUATING_AUDIENCES_COMBINED' => "Evaluating audiences for rule '%s': %s."
+      }.merge(AUDIENCE_EVALUATION_LOGS).freeze
 
       DECISION_NOTIFICATION_TYPES = {
         'AB_TEST' => 'ab-test',

--- a/spec/audience_spec.rb
+++ b/spec/audience_spec.rb
@@ -32,9 +32,9 @@ describe Optimizely::Audience do
     experiment['audienceConditions'] = []
 
     expect(Optimizely::Audience.user_meets_audience_conditions?(config,
-                                                    experiment,
-                                                    user_attributes,
-                                                    spy_logger)).to be true
+                                                                experiment,
+                                                                user_attributes,
+                                                                spy_logger)).to be true
 
     # Audience Ids exist but Audience Conditions is Empty
     experiment = config.experiment_key_map['test_experiment']
@@ -42,9 +42,9 @@ describe Optimizely::Audience do
     experiment['audienceConditions'] = []
 
     expect(Optimizely::Audience.user_meets_audience_conditions?(config,
-                                                    experiment,
-                                                    user_attributes,
-                                                    spy_logger)).to be true
+                                                                experiment,
+                                                                user_attributes,
+                                                                spy_logger)).to be true
 
     # Audience Ids is Empty and  Audience Conditions is nil
     experiment = config.experiment_key_map['test_experiment']
@@ -52,9 +52,9 @@ describe Optimizely::Audience do
     experiment['audienceConditions'] = nil
 
     expect(Optimizely::Audience.user_meets_audience_conditions?(config,
-                                                    experiment,
-                                                    user_attributes,
-                                                    spy_logger)).to be true
+                                                                experiment,
+                                                                user_attributes,
+                                                                spy_logger)).to be true
   end
 
   it 'should pass conditions when audience conditions exist else audienceIds are passed' do
@@ -66,17 +66,17 @@ describe Optimizely::Audience do
     # Both Audience Ids and Conditions exist
     experiment['audienceConditions'] = ['and', %w[or 3468206642 3988293898], %w[or 3988293899 3468206646 3468206647 3468206644 3468206643]]
     Optimizely::Audience.user_meets_audience_conditions?(config,
-                                             experiment,
-                                             user_attributes,
-                                             spy_logger)
+                                                         experiment,
+                                                         user_attributes,
+                                                         spy_logger)
     expect(Optimizely::ConditionTreeEvaluator).to have_received(:evaluate).with(experiment['audienceConditions'], any_args).once
 
     # Audience Ids exist but Audience Conditions is nil
     experiment['audienceConditions'] = nil
     Optimizely::Audience.user_meets_audience_conditions?(config,
-                                             experiment,
-                                             user_attributes,
-                                             spy_logger)
+                                                         experiment,
+                                                         user_attributes,
+                                                         spy_logger)
     expect(Optimizely::ConditionTreeEvaluator).to have_received(:evaluate).with(experiment['audienceIds'], any_args).once
   end
 
@@ -86,14 +86,14 @@ describe Optimizely::Audience do
 
     # attributes set to empty dict
     expect(Optimizely::Audience.user_meets_audience_conditions?(config,
-                                                    experiment,
-                                                    {},
-                                                    spy_logger)).to be false
+                                                                experiment,
+                                                                {},
+                                                                spy_logger)).to be false
     # attributes set to nil
     expect(Optimizely::Audience.user_meets_audience_conditions?(config,
-                                                    experiment,
-                                                    nil,
-                                                    spy_logger)).to be false
+                                                                experiment,
+                                                                nil,
+                                                                spy_logger)).to be false
     # asserts nil attributes default to empty dict
     expect(Optimizely::CustomAttributeConditionEvaluator).to have_received(:new).with({}, spy_logger).twice
   end
@@ -105,9 +105,9 @@ describe Optimizely::Audience do
     }
     allow(Optimizely::ConditionTreeEvaluator).to receive(:evaluate).and_return(true)
     expect(Optimizely::Audience.user_meets_audience_conditions?(config,
-                                                    experiment,
-                                                    user_attributes,
-                                                    spy_logger)).to be true
+                                                                experiment,
+                                                                user_attributes,
+                                                                spy_logger)).to be true
   end
 
   it 'should return false for user_meets_audience_conditions? when condition tree evaluator returns false or nil' do
@@ -119,16 +119,16 @@ describe Optimizely::Audience do
     # condition tree evaluator returns nil
     allow(Optimizely::ConditionTreeEvaluator).to receive(:evaluate).and_return(nil)
     expect(Optimizely::Audience.user_meets_audience_conditions?(config,
-                                                    experiment,
-                                                    user_attributes,
-                                                    spy_logger)).to be false
+                                                                experiment,
+                                                                user_attributes,
+                                                                spy_logger)).to be false
 
     # condition tree evaluator returns false
     allow(Optimizely::ConditionTreeEvaluator).to receive(:evaluate).and_return(false)
     expect(Optimizely::Audience.user_meets_audience_conditions?(config,
-                                                    experiment,
-                                                    user_attributes,
-                                                    spy_logger)).to be false
+                                                                experiment,
+                                                                user_attributes,
+                                                                spy_logger)).to be false
   end
 
   it 'should correctly evaluate audience Ids and call custom attribute evaluator for leaf nodes' do
@@ -214,9 +214,9 @@ describe Optimizely::Audience do
     experiment['audienceIds'] = %w[11110]
 
     expect(Optimizely::Audience.user_meets_audience_conditions?(config,
-                                                    experiment,
-                                                    user_attributes,
-                                                    spy_logger)).to be false
+                                                                experiment,
+                                                                user_attributes,
+                                                                spy_logger)).to be false
     expect(spy_logger).to have_received(:log).once.with(
       Logger::DEBUG,
       "Evaluating audiences for experiment 'test_experiment_with_audience': " + '["11110"].'
@@ -237,9 +237,9 @@ describe Optimizely::Audience do
     experiment['audienceConditions'] = nil
 
     expect(Optimizely::Audience.user_meets_audience_conditions?(config,
-                                                    experiment,
-                                                    user_attributes,
-                                                    spy_logger)).to be false
+                                                                experiment,
+                                                                user_attributes,
+                                                                spy_logger)).to be false
     expect(spy_logger).to have_received(:log).once.with(
       Logger::DEBUG,
       "Evaluating audiences for experiment 'test_experiment_with_audience': " + '["11154", "11155"].'

--- a/spec/audience_spec.rb
+++ b/spec/audience_spec.rb
@@ -332,4 +332,29 @@ describe Optimizely::Audience do
       "Audiences for experiment 'audience_combinations_experiment' collectively evaluated to TRUE."
     ).ordered # Order: 7
   end
+
+  it 'should log using logging_hash and logging_key when provided' do
+    logging_hash = 'ROLLOUT_AUDIENCE_EVALUATION_LOGS'
+    logging_key = 'some_key'
+
+    user_attributes = {
+      'lasers' => 45.5
+    }
+    experiment = typed_audience_config.get_experiment_from_key('audience_combinations_experiment')
+    experiment['audienceIds'] = []
+    experiment['audienceConditions'] = ['or', %w[or 3468206647 3988293898 3468206646]]
+
+    Optimizely::Audience.user_meets_audience_conditions?(typed_audience_config, experiment, user_attributes, spy_logger, logging_hash, logging_key)
+
+    expect(spy_logger).to have_received(:log).once.with(
+      Logger::DEBUG,
+      "Evaluating audiences for rule 'some_key': "\
+       '["or", ["or", "3468206647", "3988293898", "3468206646"]].'
+    )
+
+    expect(spy_logger).to have_received(:log).once.with(
+      Logger::INFO,
+      "Audiences for rule 'some_key' collectively evaluated to TRUE."
+    )
+  end
 end

--- a/spec/audience_spec.rb
+++ b/spec/audience_spec.rb
@@ -24,14 +24,14 @@ describe Optimizely::Audience do
   let(:config) { Optimizely::DatafileProjectConfig.new(config_body_JSON, spy_logger, error_handler) }
   let(:typed_audience_config) { Optimizely::DatafileProjectConfig.new(config_typed_audience_JSON, spy_logger, error_handler) }
 
-  it 'should return true for user_in_experiment? when experiment is using no audience' do
+  it 'should return true for user_meets_audience_conditions? when experiment is using no audience' do
     user_attributes = {}
     # Both Audience Ids and Conditions are Empty
     experiment = config.experiment_key_map['test_experiment']
     experiment['audienceIds'] = []
     experiment['audienceConditions'] = []
 
-    expect(Optimizely::Audience.user_in_experiment?(config,
+    expect(Optimizely::Audience.user_meets_audience_conditions?(config,
                                                     experiment,
                                                     user_attributes,
                                                     spy_logger)).to be true
@@ -41,7 +41,7 @@ describe Optimizely::Audience do
     experiment['audienceIds'] = ['11154']
     experiment['audienceConditions'] = []
 
-    expect(Optimizely::Audience.user_in_experiment?(config,
+    expect(Optimizely::Audience.user_meets_audience_conditions?(config,
                                                     experiment,
                                                     user_attributes,
                                                     spy_logger)).to be true
@@ -51,7 +51,7 @@ describe Optimizely::Audience do
     experiment['audienceIds'] = []
     experiment['audienceConditions'] = nil
 
-    expect(Optimizely::Audience.user_in_experiment?(config,
+    expect(Optimizely::Audience.user_meets_audience_conditions?(config,
                                                     experiment,
                                                     user_attributes,
                                                     spy_logger)).to be true
@@ -65,7 +65,7 @@ describe Optimizely::Audience do
 
     # Both Audience Ids and Conditions exist
     experiment['audienceConditions'] = ['and', %w[or 3468206642 3988293898], %w[or 3988293899 3468206646 3468206647 3468206644 3468206643]]
-    Optimizely::Audience.user_in_experiment?(config,
+    Optimizely::Audience.user_meets_audience_conditions?(config,
                                              experiment,
                                              user_attributes,
                                              spy_logger)
@@ -73,24 +73,24 @@ describe Optimizely::Audience do
 
     # Audience Ids exist but Audience Conditions is nil
     experiment['audienceConditions'] = nil
-    Optimizely::Audience.user_in_experiment?(config,
+    Optimizely::Audience.user_meets_audience_conditions?(config,
                                              experiment,
                                              user_attributes,
                                              spy_logger)
     expect(Optimizely::ConditionTreeEvaluator).to have_received(:evaluate).with(experiment['audienceIds'], any_args).once
   end
 
-  it 'should return false for user_in_experiment? if there are audiences but nil or empty attributes' do
+  it 'should return false for user_meets_audience_conditions? if there are audiences but nil or empty attributes' do
     experiment = config.experiment_key_map['test_experiment_with_audience']
     allow(Optimizely::CustomAttributeConditionEvaluator).to receive(:new).and_call_original
 
     # attributes set to empty dict
-    expect(Optimizely::Audience.user_in_experiment?(config,
+    expect(Optimizely::Audience.user_meets_audience_conditions?(config,
                                                     experiment,
                                                     {},
                                                     spy_logger)).to be false
     # attributes set to nil
-    expect(Optimizely::Audience.user_in_experiment?(config,
+    expect(Optimizely::Audience.user_meets_audience_conditions?(config,
                                                     experiment,
                                                     nil,
                                                     spy_logger)).to be false
@@ -98,19 +98,19 @@ describe Optimizely::Audience do
     expect(Optimizely::CustomAttributeConditionEvaluator).to have_received(:new).with({}, spy_logger).twice
   end
 
-  it 'should return true for user_in_experiment? when condition tree evaluator returns true' do
+  it 'should return true for user_meets_audience_conditions? when condition tree evaluator returns true' do
     experiment = config.experiment_key_map['test_experiment']
     user_attributes = {
       'test_attribute' => 'test_value_1'
     }
     allow(Optimizely::ConditionTreeEvaluator).to receive(:evaluate).and_return(true)
-    expect(Optimizely::Audience.user_in_experiment?(config,
+    expect(Optimizely::Audience.user_meets_audience_conditions?(config,
                                                     experiment,
                                                     user_attributes,
                                                     spy_logger)).to be true
   end
 
-  it 'should return false for user_in_experiment? when condition tree evaluator returns false or nil' do
+  it 'should return false for user_meets_audience_conditions? when condition tree evaluator returns false or nil' do
     experiment = config.experiment_key_map['test_experiment_with_audience']
     user_attributes = {
       'browser_type' => 'firefox'
@@ -118,14 +118,14 @@ describe Optimizely::Audience do
 
     # condition tree evaluator returns nil
     allow(Optimizely::ConditionTreeEvaluator).to receive(:evaluate).and_return(nil)
-    expect(Optimizely::Audience.user_in_experiment?(config,
+    expect(Optimizely::Audience.user_meets_audience_conditions?(config,
                                                     experiment,
                                                     user_attributes,
                                                     spy_logger)).to be false
 
     # condition tree evaluator returns false
     allow(Optimizely::ConditionTreeEvaluator).to receive(:evaluate).and_return(false)
-    expect(Optimizely::Audience.user_in_experiment?(config,
+    expect(Optimizely::Audience.user_meets_audience_conditions?(config,
                                                     experiment,
                                                     user_attributes,
                                                     spy_logger)).to be false
@@ -213,7 +213,7 @@ describe Optimizely::Audience do
     }
     experiment['audienceIds'] = %w[11110]
 
-    expect(Optimizely::Audience.user_in_experiment?(config,
+    expect(Optimizely::Audience.user_meets_audience_conditions?(config,
                                                     experiment,
                                                     user_attributes,
                                                     spy_logger)).to be false
@@ -228,7 +228,7 @@ describe Optimizely::Audience do
     )
   end
 
-  it 'should log and return false for user_in_experiment? evaluates audienceIds' do
+  it 'should log and return false for user_meets_audience_conditions? evaluates audienceIds' do
     experiment = config.experiment_key_map['test_experiment_with_audience']
     user_attributes = {
       'browser_type' => 5.5
@@ -236,7 +236,7 @@ describe Optimizely::Audience do
     experiment['audienceIds'] = %w[11154 11155]
     experiment['audienceConditions'] = nil
 
-    expect(Optimizely::Audience.user_in_experiment?(config,
+    expect(Optimizely::Audience.user_meets_audience_conditions?(config,
                                                     experiment,
                                                     user_attributes,
                                                     spy_logger)).to be false
@@ -275,7 +275,7 @@ describe Optimizely::Audience do
     )
   end
 
-  it 'should log and return true for user_in_experiment? evaluates audienceConditions' do
+  it 'should log and return true for user_meets_audience_conditions? evaluates audienceConditions' do
     user_attributes = {
       'lasers' => 45.5
     }
@@ -283,7 +283,7 @@ describe Optimizely::Audience do
     experiment['audienceIds'] = []
     experiment['audienceConditions'] = ['or', %w[or 3468206647 3988293898 3468206646]]
 
-    Optimizely::Audience.user_in_experiment?(typed_audience_config, experiment, user_attributes, spy_logger)
+    Optimizely::Audience.user_meets_audience_conditions?(typed_audience_config, experiment, user_attributes, spy_logger)
 
     expect(spy_logger).to have_received(:log).once.with(
       Logger::DEBUG,

--- a/spec/bucketing_spec.rb
+++ b/spec/bucketing_spec.rb
@@ -15,6 +15,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+require 'spec_helper'
 require 'optimizely/bucketer'
 require 'optimizely/error_handler'
 require 'optimizely/logger'
@@ -66,13 +67,11 @@ describe Optimizely::Bucketer do
     experiment = config.get_experiment_from_key('group1_exp1')
     expected_variation = config.get_variation_from_id('group1_exp1', '130001')
     expect(bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')).to eq(expected_variation)
-    expect(spy_logger).to have_received(:log).exactly(4).times
+    expect(spy_logger).to have_received(:log).exactly(3).times
     expect(spy_logger).to have_received(:log).twice
                                              .with(Logger::DEBUG, "Assigned bucket 3000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
     expect(spy_logger).to have_received(:log)
       .with(Logger::INFO, "User 'test_user' is in experiment 'group1_exp1' of group 101.")
-    expect(spy_logger).to have_received(:log)
-      .with(Logger::INFO, "User 'test_user' is in variation 'g1_e1_v1' of experiment 'group1_exp1'.")
   end
 
   it 'should return nil when user is bucketed into a different mutually exclusive grouped experiment than specified' do
@@ -101,11 +100,9 @@ describe Optimizely::Bucketer do
     experiment = config.get_experiment_from_key('group2_exp1')
     expected_variation = config.get_variation_from_id('group2_exp1', '144443')
     expect(bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')).to eq(expected_variation)
-    expect(spy_logger).to have_received(:log).twice
+    expect(spy_logger).to have_received(:log).once
     expect(spy_logger).to have_received(:log)
       .with(Logger::DEBUG, "Assigned bucket 3000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
-    expect(spy_logger).to have_received(:log)
-      .with(Logger::INFO, "User 'test_user' is in variation 'g2_e1_v1' of experiment 'group2_exp1'.")
   end
 
   it 'should return nil when a user is in no variation of an overlapping grouped experiment' do
@@ -113,11 +110,9 @@ describe Optimizely::Bucketer do
 
     experiment = config.get_experiment_from_key('group2_exp1')
     expect(bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')).to be_nil
-    expect(spy_logger).to have_received(:log).twice
+    expect(spy_logger).to have_received(:log).once
     expect(spy_logger).to have_received(:log)
       .with(Logger::DEBUG, "Assigned bucket 50000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
-    expect(spy_logger).to have_received(:log)
-      .with(Logger::INFO, "User 'test_user' is in no variation.")
   end
 
   it 'should call generate_bucket_value with the proper arguments during variation bucketing' do
@@ -144,8 +139,6 @@ describe Optimizely::Bucketer do
     expect(bucketer).to receive(:find_bucket).once.and_return('')
     experiment = config.get_experiment_from_key('test_experiment')
     expect(bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')).to be_nil
-    expect(spy_logger).to have_received(:log)
-      .with(Logger::INFO, "User 'test_user' is in no variation.")
     expect(spy_logger).to have_received(:log)
       .with(Logger::DEBUG, 'Bucketed into an empty traffic range. Returning nil.')
   end
@@ -190,13 +183,9 @@ describe Optimizely::Bucketer do
 
       experiment = config.get_experiment_from_key('test_experiment')
       bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
-      expect(spy_logger).to have_received(:log).twice
+      expect(spy_logger).to have_received(:log).once
       expect(spy_logger).to have_received(:log)
         .with(Logger::DEBUG, "Assigned bucket 50 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
-      expect(spy_logger).to have_received(:log).with(
-        Logger::INFO,
-        "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
-      )
     end
 
     it 'should log the results of bucketing a user into variation 2' do
@@ -204,13 +193,9 @@ describe Optimizely::Bucketer do
 
       experiment = config.get_experiment_from_key('test_experiment')
       bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
-      expect(spy_logger).to have_received(:log).twice
+      expect(spy_logger).to have_received(:log).once
       expect(spy_logger).to have_received(:log)
         .with(Logger::DEBUG, "Assigned bucket 5050 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
-      expect(spy_logger).to have_received(:log).with(
-        Logger::INFO,
-        "User 'test_user' is in variation 'variation' of experiment 'test_experiment'."
-      )
     end
 
     it 'should log the results of bucketing a user into no variation' do
@@ -218,11 +203,9 @@ describe Optimizely::Bucketer do
 
       experiment = config.get_experiment_from_key('test_experiment')
       bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
-      expect(spy_logger).to have_received(:log).twice
+      expect(spy_logger).to have_received(:log).once
       expect(spy_logger).to have_received(:log)
         .with(Logger::DEBUG, "Assigned bucket 50000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
-      expect(spy_logger).to have_received(:log)
-        .with(Logger::INFO, "User 'test_user' is in no variation.")
     end
   end
 end

--- a/spec/bucketing_spec.rb
+++ b/spec/bucketing_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2017, 2019 Optimizely and contributors
+#    Copyright 2016-2017, 2019-2020 Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -516,9 +516,9 @@ describe Optimizely::DecisionService do
 
             # make sure we only checked the audience for the first rule
             expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?).once
-                                                                               .with(config, rollout['experiments'][0], user_attributes, spy_logger)
+                                                                                           .with(config, rollout['experiments'][0], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 1)
             expect(Optimizely::Audience).not_to have_received(:user_meets_audience_conditions?)
-              .with(config, rollout['experiments'][1], user_attributes, spy_logger)
+              .with(config, rollout['experiments'][1], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 2)
           end
         end
 
@@ -541,9 +541,9 @@ describe Optimizely::DecisionService do
 
             # make sure we only checked the audience for the first rule
             expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?).once
-                                                                               .with(config, rollout['experiments'][0], user_attributes, spy_logger)
+                                                                                           .with(config, rollout['experiments'][0], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 1)
             expect(Optimizely::Audience).not_to have_received(:user_meets_audience_conditions?)
-              .with(config, rollout['experiments'][1], user_attributes, spy_logger)
+              .with(config, rollout['experiments'][1], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 2)
           end
         end
       end
@@ -559,7 +559,7 @@ describe Optimizely::DecisionService do
         allow(Optimizely::Audience).to receive(:user_meets_audience_conditions?).and_return(false)
 
         allow(Optimizely::Audience).to receive(:user_meets_audience_conditions?)
-          .with(config, everyone_else_experiment, user_attributes, spy_logger)
+          .with(config, everyone_else_experiment, user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 'Everyone Else')
           .and_return(true)
         allow(decision_service.bucketer).to receive(:bucket)
           .with(config, everyone_else_experiment, user_id, user_id)
@@ -569,11 +569,11 @@ describe Optimizely::DecisionService do
 
         # verify we tried to bucket in all targeting rules and the everyone else rule
         expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?).once
-                                                                           .with(config, rollout['experiments'][0], user_attributes, spy_logger)
+                                                                                       .with(config, rollout['experiments'][0], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 1)
         expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?)
-          .with(config, rollout['experiments'][1], user_attributes, spy_logger)
+          .with(config, rollout['experiments'][1], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 2)
         expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?)
-          .with(config, rollout['experiments'][2], user_attributes, spy_logger)
+          .with(config, rollout['experiments'][2], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 'Everyone Else')
 
         # verify log messages
         experiment = rollout['experiments'][0]
@@ -603,11 +603,11 @@ describe Optimizely::DecisionService do
 
         # verify we tried to bucket in all targeting rules and the everyone else rule
         expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?).once
-                                                                           .with(config, rollout['experiments'][0], user_attributes, spy_logger)
+                                                                                       .with(config, rollout['experiments'][0], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 1)
         expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?)
-          .with(config, rollout['experiments'][1], user_attributes, spy_logger)
+          .with(config, rollout['experiments'][1], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 2)
         expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?)
-          .with(config, rollout['experiments'][2], user_attributes, spy_logger)
+          .with(config, rollout['experiments'][2], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 'Everyone Else')
 
         # verify log messages
         experiment = rollout['experiments'][0]

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -562,25 +562,19 @@ describe Optimizely::DecisionService do
         expect(decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes)).to eq(expected_decision)
 
         # verify we tried to bucket in all targeting rules and the everyone else rule
-        expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?).once
-                                                                                       .with(config, rollout['experiments'][0], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 1)
+        expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?)
+          .with(config, rollout['experiments'][0], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 1)
         expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?)
           .with(config, rollout['experiments'][1], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 2)
         expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?)
           .with(config, rollout['experiments'][2], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 'Everyone Else')
 
         # verify log messages
-        experiment = rollout['experiments'][0]
-        audience_id = experiment['audienceIds'][0]
-        audience_name = config.get_audience_from_id(audience_id)['name']
-        expect(spy_logger).to have_received(:log).once
-                                                 .with(Logger::DEBUG, "User '#{user_id}' does not meet the conditions to be in rollout rule for audience '#{audience_name}'.")
+        expect(spy_logger).to have_received(:log).with(Logger::DEBUG, "User '#{user_id}' does not meet the audience conditions for targeting rule '1'.")
 
-        experiment = rollout['experiments'][1]
-        audience_id = experiment['audienceIds'][0]
-        audience_name = config.get_audience_from_id(audience_id)['name']
-        expect(spy_logger).to have_received(:log).once
-                                                 .with(Logger::DEBUG, "User '#{user_id}' does not meet the conditions to be in rollout rule for audience '#{audience_name}'.")
+        expect(spy_logger).to have_received(:log).with(Logger::DEBUG, "User '#{user_id}' does not meet the audience conditions for targeting rule '2'.")
+
+        expect(spy_logger).to have_received(:log).with(Logger::DEBUG, "User '#{user_id}' meets the audience conditions for targeting rule 'Everyone Else'.")
       end
 
       it 'should not bucket the user into the "Everyone Else" rule when audience mismatch' do
@@ -604,17 +598,11 @@ describe Optimizely::DecisionService do
           .with(config, rollout['experiments'][2], user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 'Everyone Else')
 
         # verify log messages
-        experiment = rollout['experiments'][0]
-        audience_id = experiment['audienceIds'][0]
-        audience_name = config.get_audience_from_id(audience_id)['name']
-        expect(spy_logger).to have_received(:log).once
-                                                 .with(Logger::DEBUG, "User '#{user_id}' does not meet the conditions to be in rollout rule for audience '#{audience_name}'.")
+        expect(spy_logger).to have_received(:log).with(Logger::DEBUG, "User '#{user_id}' does not meet the audience conditions for targeting rule '1'.")
 
-        experiment = rollout['experiments'][1]
-        audience_id = experiment['audienceIds'][0]
-        audience_name = config.get_audience_from_id(audience_id)['name']
-        expect(spy_logger).to have_received(:log).twice
-                                                 .with(Logger::DEBUG, "User '#{user_id}' does not meet the conditions to be in rollout rule for audience '#{audience_name}'.")
+        expect(spy_logger).to have_received(:log).with(Logger::DEBUG, "User '#{user_id}' does not meet the audience conditions for targeting rule '2'.")
+
+        expect(spy_logger).to have_received(:log).with(Logger::DEBUG, "User '#{user_id}' does not meet the audience conditions for targeting rule 'Everyone Else'.")
       end
     end
   end

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2017-2019, Optimizely and contributors
+#    Copyright 2017-2020, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -69,6 +69,14 @@ describe Optimizely::DecisionService do
         .once.with(Logger::INFO, "User 'test_user' is in variation 'control' of experiment 'test_experiment'.")
       expect(decision_service).to have_received(:get_whitelisted_variation_id).once
       expect(decision_service.bucketer).to have_received(:bucket).once
+    end
+
+    it 'should return nil when user ID is not bucketed' do
+      allow(decision_service.bucketer).to receive(:bucket).and_return(nil)
+      expect(decision_service.get_variation(config, 'test_experiment', 'test_user')).to eq(nil)
+
+      expect(spy_logger).to have_received(:log)
+        .once.with(Logger::INFO, "User 'test_user' is in no variation.")
     end
 
     it 'should return correct variation ID if user ID is in whitelisted Variations and variation is valid' do

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -659,8 +659,6 @@ describe Optimizely::DecisionService do
           allow(decision_service).to receive(:get_variation_for_feature_rollout).and_return(expected_decision)
 
           expect(decision_service.get_variation_for_feature(config, feature_flag, user_id, user_attributes)).to eq(expected_decision)
-          expect(spy_logger).to have_received(:log).once
-                                                   .with(Logger::INFO, "User '#{user_id}' is bucketed into a rollout for feature flag '#{feature_flag['key']}'.")
         end
       end
 
@@ -671,8 +669,6 @@ describe Optimizely::DecisionService do
           allow(decision_service).to receive(:get_variation_for_feature_rollout).and_return(nil)
 
           expect(decision_service.get_variation_for_feature(config, feature_flag, user_id, user_attributes)).to eq(nil)
-          expect(spy_logger).to have_received(:log).once
-                                                   .with(Logger::INFO, "User '#{user_id}' is not bucketed into a rollout for feature flag '#{feature_flag['key']}'.")
         end
       end
     end

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -392,9 +392,6 @@ describe Optimizely::DecisionService do
             Optimizely::DecisionService::DECISION_SOURCES['FEATURE_TEST']
           )
           expect(decision_service.get_variation_for_feature_experiment(config, feature_flag, 'user_1', user_attributes)).to eq(expected_decision)
-
-          expect(spy_logger).to have_received(:log).once
-                                                   .with(Logger::INFO, "The user 'user_1' is bucketed into experiment 'test_experiment_multivariate' of feature 'multi_variate_feature'.")
         end
       end
     end
@@ -418,9 +415,6 @@ describe Optimizely::DecisionService do
         it 'should return the variation the user is bucketed into' do
           feature_flag = config.feature_flag_key_map['mutex_group_feature']
           expect(decision_service.get_variation_for_feature_experiment(config, feature_flag, user_id, user_attributes)).to eq(expected_decision)
-
-          expect(spy_logger).to have_received(:log).once
-                                                   .with(Logger::INFO, "The user 'user_1' is bucketed into experiment 'group1_exp1' of feature 'mutex_group_feature'.")
         end
       end
 

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -15,6 +15,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+require 'spec_helper'
 require 'optimizely/decision_service'
 require 'optimizely/error_handler'
 require 'optimizely/logger'

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -2954,7 +2954,7 @@ describe 'Optimizely' do
 
       expect(spy_logger).to have_received(:log).once.with(
         Logger::DEBUG,
-        "Feature 'integer_single_variable_feature' for variation 'control' is not enabled. Returning the default variable value '7'."
+        "Feature 'integer_single_variable_feature' is not enabled for user 'test_user'. Returning the default variable value '7'."
       )
     end
 
@@ -3068,7 +3068,7 @@ describe 'Optimizely' do
 
       expect(spy_logger).to have_received(:log).once.with(
         Logger::DEBUG,
-        "Feature 'boolean_single_variable_feature' for variation '177773' is not enabled. Returning the default variable value 'true'."
+        "Feature 'boolean_single_variable_feature' is not enabled for user 'test_user'. Returning the default variable value 'true'."
       )
     end
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1475,7 +1475,6 @@ describe 'Optimizely' do
       it 'should return false for feature rollout when typed audience mismatch' do
         expect(@project_typed_audience_instance.is_feature_enabled('feat', 'test_user', {})).to be false
 
-        expect(spy_logger).to have_received(:log).once.with(Logger::INFO, "User 'test_user' is not bucketed into a rollout for feature flag 'feat'.")
         expect(spy_logger).to have_received(:log).once.with(Logger::INFO, "Feature 'feat' is not enabled for user 'test_user'.")
       end
 
@@ -1497,7 +1496,6 @@ describe 'Optimizely' do
         # and no audience in the other branch of the 'and' matches either
         expect(@project_typed_audience_instance.is_feature_enabled('feat2', 'test_user', 'house' => 'Lannister')).to be false
 
-        expect(spy_logger).to have_received(:log).once.with(Logger::INFO, "User 'test_user' is not bucketed into a rollout for feature flag 'feat2'.")
         expect(spy_logger).to have_received(:log).once.with(Logger::INFO, "Feature 'feat2' is not enabled for user 'test_user'.")
       end
     end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1942,7 +1942,7 @@ describe 'Optimizely' do
           expect(spy_logger).to have_received(:log).once
                                                    .with(
                                                      Logger::DEBUG,
-                                                     "Variable 'string_variable' is not used in variation '177775'. Returning the default variable value 'wingardium leviosa'."
+                                                     "Variable value is not defined. Returning the default variable value 'wingardium leviosa' for variable 'string_variable'."
                                                    )
         end
       end
@@ -2020,7 +2020,7 @@ describe 'Optimizely' do
         expect(spy_logger).to have_received(:log).once
                                                  .with(
                                                    Logger::INFO,
-                                                   "User 'test_user' was not bucketed into any variation for feature flag 'string_single_variable_feature'. Returning the default variable value 'wingardium leviosa'."
+                                                   "User 'test_user' was not bucketed into experiment or rollout for feature flag 'string_single_variable_feature'. Returning the default variable value 'wingardium leviosa'."
                                                  )
       end
     end
@@ -2108,7 +2108,7 @@ describe 'Optimizely' do
           expect(spy_logger).to have_received(:log).once
                                                    .with(
                                                      Logger::DEBUG,
-                                                     "Variable 'json_variable' is not used in variation '177775'. Returning the default variable value '{ \"val\": \"wingardium leviosa\" }'."
+                                                     "Variable value is not defined. Returning the default variable value '{ \"val\": \"wingardium leviosa\" }' for variable 'json_variable'."
                                                    )
         end
       end
@@ -2210,7 +2210,7 @@ describe 'Optimizely' do
         expect(spy_logger).to have_received(:log).once
                                                  .with(
                                                    Logger::INFO,
-                                                   "User 'test_user' was not bucketed into any variation for feature flag 'json_single_variable_feature'. Returning the default variable value '{ \"val\": \"wingardium leviosa\" }'."
+                                                   "User 'test_user' was not bucketed into experiment or rollout for feature flag 'json_single_variable_feature'. Returning the default variable value '{ \"val\": \"wingardium leviosa\" }'."
                                                  )
       end
     end
@@ -2452,12 +2452,12 @@ describe 'Optimizely' do
           expect(spy_logger).to have_received(:log).once
                                                    .with(
                                                      Logger::DEBUG,
-                                                     "Variable 'json_variable' is not used in variation '177775'. Returning the default variable value '{ \"val\": \"default json\" }'."
+                                                     "Variable value is not defined. Returning the default variable value '{ \"val\": \"default json\" }' for variable 'json_variable'."
                                                    )
           expect(spy_logger).to have_received(:log).once
                                                    .with(
                                                      Logger::DEBUG,
-                                                     "Variable 'string_variable' is not used in variation '177775'. Returning the default variable value 'default string'."
+                                                     "Variable value is not defined. Returning the default variable value '{ \"val\": \"default json\" }' for variable 'json_variable'."
                                                    )
         end
       end
@@ -2582,27 +2582,27 @@ describe 'Optimizely' do
         expect(spy_logger).to have_received(:log).once
                                                  .with(
                                                    Logger::INFO,
-                                                   "User 'test_user' was not bucketed into any variation for feature flag 'all_variables_feature'. Returning the default variable value '{ \"val\": \"default json\" }'."
+                                                   "User 'test_user' was not bucketed into experiment or rollout for feature flag 'all_variables_feature'. Returning the default variable value '{ \"val\": \"default json\" }'."
                                                  )
         expect(spy_logger).to have_received(:log).once
                                                  .with(
                                                    Logger::INFO,
-                                                   "User 'test_user' was not bucketed into any variation for feature flag 'all_variables_feature'. Returning the default variable value 'default string'."
+                                                   "User 'test_user' was not bucketed into experiment or rollout for feature flag 'all_variables_feature'. Returning the default variable value 'default string'."
                                                  )
         expect(spy_logger).to have_received(:log).once
                                                  .with(
                                                    Logger::INFO,
-                                                   "User 'test_user' was not bucketed into any variation for feature flag 'all_variables_feature'. Returning the default variable value 'false'."
+                                                   "User 'test_user' was not bucketed into experiment or rollout for feature flag 'all_variables_feature'. Returning the default variable value 'false'."
                                                  )
         expect(spy_logger).to have_received(:log).once
                                                  .with(
                                                    Logger::INFO,
-                                                   "User 'test_user' was not bucketed into any variation for feature flag 'all_variables_feature'. Returning the default variable value '1.99'."
+                                                   "User 'test_user' was not bucketed into experiment or rollout for feature flag 'all_variables_feature'. Returning the default variable value '1.99'."
                                                  )
         expect(spy_logger).to have_received(:log).once
                                                  .with(
                                                    Logger::INFO,
-                                                   "User 'test_user' was not bucketed into any variation for feature flag 'all_variables_feature'. Returning the default variable value '10'."
+                                                   "User 'test_user' was not bucketed into experiment or rollout for feature flag 'all_variables_feature'. Returning the default variable value '10'."
                                                  )
       end
     end
@@ -2665,7 +2665,7 @@ describe 'Optimizely' do
           expect(spy_logger).to have_received(:log).once
                                                    .with(
                                                      Logger::DEBUG,
-                                                     "Variable 'string_variable' is not used in variation '177775'. Returning the default variable value 'wingardium leviosa'."
+                                                     "Variable value is not defined. Returning the default variable value 'wingardium leviosa' for variable 'string_variable'."
                                                    )
         end
       end
@@ -2768,7 +2768,7 @@ describe 'Optimizely' do
         expect(spy_logger).to have_received(:log).once
                                                  .with(
                                                    Logger::INFO,
-                                                   "User 'test_user' was not bucketed into any variation for feature flag 'string_single_variable_feature'. Returning the default variable value 'wingardium leviosa'."
+                                                   "User 'test_user' was not bucketed into experiment or rollout for feature flag 'string_single_variable_feature'. Returning the default variable value 'wingardium leviosa'."
                                                  )
       end
     end


### PR DESCRIPTION
## Summary
- This PR modifies log messages to be explicit when it's evaluating an experiment and when it's doing so for a Rollout. 


## Test plan
- Added additional unit test to assert audience logs for rollouts. 
- Existing tests should continue to pass.

