### PR TITLE
(fix): allow user_attributes to be evaluated with symbol or string keys

### DIFF
--- a/lib/optimizely/custom_attribute_condition_evaluator.rb
+++ b/lib/optimizely/custom_attribute_condition_evaluator.rb
@@ -58,6 +58,18 @@ module Optimizely
     def initialize(user_attributes, logger)
       @user_attributes = user_attributes
       @logger = logger
+
+      # configure user_attributes to access with string or symbol
+      @user_attributes.default_proc = proc do |h, k|
+        case k
+        when String
+          sym = k.to_sym
+          h[sym] if h.key?(sym)
+        when Symbol
+          str = k.to_s
+          h[str] if h.key?(str)
+        end
+      end
     end
 
     def evaluate(leaf_condition)
@@ -79,7 +91,7 @@ module Optimizely
 
       condition_match = leaf_condition['match'] || EXACT_MATCH_TYPE
 
-      if !@user_attributes.key?(leaf_condition['name']) && condition_match != EXISTS_MATCH_TYPE
+      if !(@user_attributes.key?(leaf_condition['name']) || @user_attributes.key?(leaf_condition['name'].to_sym)) && condition_match != EXISTS_MATCH_TYPE
         @logger.log(
           Logger::DEBUG,
           format(


### PR DESCRIPTION
## Summary
- Change the default_proc of the user_attributes hash to check for string keys or symbol keys and return the appropriate value.

The SDK allows a user to send the user_attributes hash with symbol keys or with string keys. If passing a hash with symbol keys, the evaluate check will always return nil as the method only checks for string keys. This will enable the attribute evaluation to evaluate string or symbol keys.

Specifically, this check here makes sure the hash has symbol or string keys: https://github.com/optimizely/ruby-sdk/blob/73fdcf663396384f1307a9a8cc3e75d876342b97/lib/optimizely/helpers/validator.rb#L37-L50 but it never evaluates symbol keys.

## Test plan
- Added unit tests to pass in user_attributes with a symbol hash and ensure new tests and existing tests still passed.

## Issues
- none opened at this time.
