### PR TITLE
refactor: Changed the way reasons are being returned from decide APIs

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -878,7 +878,7 @@ module Optimizely
 
       return nil unless user_inputs_valid?(attributes)
 
-      variation_id = @decision_service.get_variation(config, experiment_key, user_id, attributes)
+      variation_id, = @decision_service.get_variation(config, experiment_key, user_id, attributes)
       variation = config.get_variation_from_id(experiment_key, variation_id) unless variation_id.nil?
       variation_key = variation['key'] if variation
       decision_notification_type = if config.feature_experiment?(experiment['id'])

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -405,7 +405,7 @@ module Optimizely
       config = project_config
 
       forced_variation_key = nil
-      forced_variation = @decision_service.get_forced_variation(config, experiment_key, user_id)
+      forced_variation, = @decision_service.get_forced_variation(config, experiment_key, user_id)
       forced_variation_key = forced_variation['key'] if forced_variation
 
       forced_variation_key

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -199,7 +199,8 @@ module Optimizely
       experiment = nil
       decision_source = Optimizely::DecisionService::DECISION_SOURCES['ROLLOUT']
 
-      decision = @decision_service.get_variation_for_feature(config, feature_flag, user_id, attributes, decide_options, reasons)
+      decision, reasons_received = @decision_service.get_variation_for_feature(config, feature_flag, user_id, attributes, decide_options)
+      reasons.push(*reasons_received)
 
       # Send impression event if Decision came from a feature test and decide options doesn't include disableDecisionEvent
       if decision.is_a?(Optimizely::DecisionService::Decision)
@@ -489,7 +490,7 @@ module Optimizely
         return false
       end
 
-      decision = @decision_service.get_variation_for_feature(config, feature_flag, user_id, attributes)
+      decision, = @decision_service.get_variation_for_feature(config, feature_flag, user_id, attributes)
 
       feature_enabled = false
       source_string = Optimizely::DecisionService::DECISION_SOURCES['ROLLOUT']
@@ -738,7 +739,7 @@ module Optimizely
         return nil
       end
 
-      decision = @decision_service.get_variation_for_feature(config, feature_flag, user_id, attributes)
+      decision, = @decision_service.get_variation_for_feature(config, feature_flag, user_id, attributes)
       variation = decision ? decision['variation'] : nil
       feature_enabled = variation ? variation['featureEnabled'] : false
       all_variables = {}
@@ -944,7 +945,7 @@ module Optimizely
         return nil
       end
 
-      decision = @decision_service.get_variation_for_feature(config, feature_flag, user_id, attributes)
+      decision, = @decision_service.get_variation_for_feature(config, feature_flag, user_id, attributes)
       variation = decision ? decision['variation'] : nil
       feature_enabled = variation ? variation['featureEnabled'] : false
 

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -53,7 +53,7 @@ module Optimizely
       # Return true if there are no audiences
       if audience_conditions.empty?
         message = format(logs_hash['AUDIENCE_EVALUATION_RESULT_COMBINED'], logging_key, 'TRUE')
-        logger.log(Logger::INFO)
+        logger.log(Logger::INFO, message)
         decide_reasons.push(message)
         return true, decide_reasons
       end

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -48,7 +48,6 @@ module Optimizely
 
       message = format(logs_hash['EVALUATING_AUDIENCES_COMBINED'], logging_key, audience_conditions)
       logger.log(Logger::DEBUG, message)
-      decide_reasons.push(message)
 
       # Return true if there are no audiences
       if audience_conditions.empty?

--- a/lib/optimizely/bucketer.rb
+++ b/lib/optimizely/bucketer.rb
@@ -58,7 +58,7 @@ module Optimizely
         if Helpers::Group.random_policy?(group)
           traffic_allocations = group.fetch('trafficAllocation')
           bucketed_experiment_id, find_bucket_reasons = find_bucket(bucketing_id, user_id, group_id, traffic_allocations)
-          decide_reasons.push(find_bucket_reasons)
+          decide_reasons.push(*find_bucket_reasons)
 
           # return if the user is not bucketed into any experiment
           unless bucketed_experiment_id
@@ -85,7 +85,7 @@ module Optimizely
 
       traffic_allocations = experiment['trafficAllocation']
       variation_id, find_bucket_reasons = find_bucket(bucketing_id, user_id, experiment_id, traffic_allocations)
-      decide_reasons.push(find_bucket_reasons)
+      decide_reasons.push(*find_bucket_reasons)
 
       if variation_id && variation_id != ''
         variation = project_config.get_variation_from_id(experiment_key, variation_id)

--- a/lib/optimizely/bucketer.rb
+++ b/lib/optimizely/bucketer.rb
@@ -35,7 +35,7 @@ module Optimizely
       @bucket_seed = HASH_SEED
     end
 
-    def bucket(project_config, experiment, bucketing_id, user_id, decide_reasons = nil)
+    def bucket(project_config, experiment, bucketing_id, user_id)
       # Determines ID of variation to be shown for a given experiment key and user ID.
       #
       # project_config - Instance of ProjectConfig
@@ -44,7 +44,9 @@ module Optimizely
       # user_id - String ID for user.
       #
       # Returns variation in which visitor with ID user_id has been placed. Nil if no variation.
-      return nil if experiment.nil?
+      return nil, [] if experiment.nil?
+
+      decide_reasons = []
 
       # check if experiment is in a group; if so, check if user is bucketed into specified experiment
       # this will not affect evaluation of rollout rules.
@@ -55,48 +57,52 @@ module Optimizely
         group = project_config.group_id_map.fetch(group_id)
         if Helpers::Group.random_policy?(group)
           traffic_allocations = group.fetch('trafficAllocation')
-          bucketed_experiment_id = find_bucket(bucketing_id, user_id, group_id, traffic_allocations)
+          bucketed_experiment_id, find_bucket_reasons = find_bucket(bucketing_id, user_id, group_id, traffic_allocations)
+          decide_reasons.push(find_bucket_reasons)
+
           # return if the user is not bucketed into any experiment
           unless bucketed_experiment_id
             message = "User '#{user_id}' is in no experiment."
             @logger.log(Logger::INFO, message)
-            decide_reasons&.push(message)
-            return nil
+            decide_reasons.push(message)
+            return nil, decide_reasons
           end
 
           # return if the user is bucketed into a different experiment than the one specified
           if bucketed_experiment_id != experiment_id
             message = "User '#{user_id}' is not in experiment '#{experiment_key}' of group #{group_id}."
             @logger.log(Logger::INFO, message)
-            decide_reasons&.push(message)
-            return nil
+            decide_reasons.push(message)
+            return nil, decide_reasons
           end
 
           # continue bucketing if the user is bucketed into the experiment specified
           message = "User '#{user_id}' is in experiment '#{experiment_key}' of group #{group_id}."
           @logger.log(Logger::INFO, message)
-          decide_reasons&.push(message)
+          decide_reasons.push(message)
         end
       end
 
       traffic_allocations = experiment['trafficAllocation']
-      variation_id = find_bucket(bucketing_id, user_id, experiment_id, traffic_allocations, decide_reasons)
+      variation_id, find_bucket_reasons = find_bucket(bucketing_id, user_id, experiment_id, traffic_allocations)
+      decide_reasons.push(find_bucket_reasons)
+
       if variation_id && variation_id != ''
         variation = project_config.get_variation_from_id(experiment_key, variation_id)
-        return variation
+        return variation, decide_reasons
       end
 
       # Handle the case when the traffic range is empty due to sticky bucketing
       if variation_id == ''
         message = 'Bucketed into an empty traffic range. Returning nil.'
         @logger.log(Logger::DEBUG, message)
-        decide_reasons&.push(message)
+        decide_reasons.push(message)
       end
 
-      nil
+      [nil, decide_reasons]
     end
 
-    def find_bucket(bucketing_id, user_id, parent_id, traffic_allocations, decide_reasons = nil)
+    def find_bucket(bucketing_id, user_id, parent_id, traffic_allocations)
       # Helper function to find the matching entity ID for a given bucketing value in a list of traffic allocations.
       #
       # bucketing_id - String A customer-assigned value user to generate bucketing key
@@ -104,23 +110,25 @@ module Optimizely
       # parent_id - String entity ID to use for bucketing ID
       # traffic_allocations - Array of traffic allocations
       #
-      # Returns entity ID corresponding to the provided bucket value or nil if no match is found.
+      # Returns and array of two values where first value is the entity ID corresponding to the provided bucket value
+      # or nil if no match is found. The second value contains the array of reasons stating how the deicision was taken
+      decide_reasons = []
       bucketing_key = format(BUCKETING_ID_TEMPLATE, bucketing_id: bucketing_id, entity_id: parent_id)
       bucket_value = generate_bucket_value(bucketing_key)
 
       message = "Assigned bucket #{bucket_value} to user '#{user_id}' with bucketing ID: '#{bucketing_id}'."
       @logger.log(Logger::DEBUG, message)
-      decide_reasons&.push(message)
+      decide_reasons.push(message)
 
       traffic_allocations.each do |traffic_allocation|
         current_end_of_range = traffic_allocation['endOfRange']
         if bucket_value < current_end_of_range
           entity_id = traffic_allocation['entityId']
-          return entity_id
+          return entity_id, decide_reasons
         end
       end
 
-      nil
+      [nil, decide_reasons]
     end
 
     private

--- a/lib/optimizely/bucketer.rb
+++ b/lib/optimizely/bucketer.rb
@@ -118,7 +118,6 @@ module Optimizely
 
       message = "Assigned bucket #{bucket_value} to user '#{user_id}' with bucketing ID: '#{bucketing_id}'."
       @logger.log(Logger::DEBUG, message)
-      decide_reasons.push(message)
 
       traffic_allocations.each do |traffic_allocation|
         current_end_of_range = traffic_allocation['endOfRange']

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -343,7 +343,6 @@ module Optimizely
       unless @forced_variation_map.key? user_id
         message = "User '#{user_id}' is not in the forced variation map."
         @logger.log(Logger::DEBUG, message)
-        decide_reasons.push(message)
         return nil, decide_reasons
       end
 

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -425,7 +425,7 @@ module Optimizely
       variation_id = decision[:variation_id]
       return variation_id, nil if project_config.variation_id_exists?(experiment_id, variation_id)
 
-      message = "User '#{user_profile['user_id']}' was previously bucketed into variation ID '#{variation_id}' for experiment '#{experiment_id}', but no matching variation was found. Re-bucketing user."
+      message = "User '#{user_profile[:user_id]}' was previously bucketed into variation ID '#{variation_id}' for experiment '#{experiment_id}', but no matching variation was found. Re-bucketing user."
       @logger.log(Logger::INFO, message)
 
       [nil, message]

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -132,7 +132,7 @@ module Optimizely
       [variation_id, decide_reasons]
     end
 
-    def get_variation_for_feature(project_config, feature_flag, user_id, attributes = nil, decide_options = [], decide_reasons = nil)
+    def get_variation_for_feature(project_config, feature_flag, user_id, attributes = nil, decide_options = [])
       # Get the variation the user is bucketed into for the given FeatureFlag.
       #
       # project_config - project_config - Instance of ProjectConfig
@@ -142,15 +142,17 @@ module Optimizely
       #
       # Returns Decision struct (nil if the user is not bucketed into any of the experiments on the feature)
 
+      decide_reasons = []
+
       # check if the feature is being experiment on and whether the user is bucketed into the experiment
       decision, reasons_received = get_variation_for_feature_experiment(project_config, feature_flag, user_id, attributes, decide_options)
-      decide_reasons&.push(*reasons_received)
-      return decision unless decision.nil?
+      decide_reasons.push(*reasons_received)
+      return decision, decide_reasons unless decision.nil?
 
       decision, reasons_received = get_variation_for_feature_rollout(project_config, feature_flag, user_id, attributes)
-      decide_reasons&.push(*reasons_received)
+      decide_reasons.push(*reasons_received)
 
-      decision
+      [decision, decide_reasons]
     end
 
     def get_variation_for_feature_experiment(project_config, feature_flag, user_id, attributes = nil, decide_options = [])

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -107,7 +107,8 @@ module Optimizely
       end
 
       # Bucket normally
-      variation = @bucketer.bucket(project_config, experiment, bucketing_id, user_id, decide_reasons)
+      variation, bucket_reasons = @bucketer.bucket(project_config, experiment, bucketing_id, user_id)
+      decide_reasons&.push(*bucket_reasons)
       variation_id = variation ? variation['id'] : nil
 
       message = ''
@@ -241,7 +242,8 @@ module Optimizely
         decide_reasons&.push(message)
 
         # Evaluate if user satisfies the traffic allocation for this rollout rule
-        variation = @bucketer.bucket(project_config, rollout_rule, bucketing_id, user_id, decide_reasons)
+        variation, bucket_reasons = @bucketer.bucket(project_config, rollout_rule, bucketing_id, user_id)
+        decide_reasons&.push(*bucket_reasons)
         return Decision.new(rollout_rule, variation, DECISION_SOURCES['ROLLOUT']) unless variation.nil?
 
         break
@@ -262,7 +264,8 @@ module Optimizely
       @logger.log(Logger::DEBUG, message)
       decide_reasons&.push(message)
 
-      variation = @bucketer.bucket(project_config, everyone_else_experiment, bucketing_id, user_id, decide_reasons)
+      variation, bucket_reasons = @bucketer.bucket(project_config, everyone_else_experiment, bucketing_id, user_id)
+      decide_reasons&.push(*bucket_reasons)
       return Decision.new(everyone_else_experiment, variation, DECISION_SOURCES['ROLLOUT']) unless variation.nil?
 
       nil

--- a/spec/audience_spec.rb
+++ b/spec/audience_spec.rb
@@ -43,7 +43,7 @@ describe Optimizely::Audience do
 
     user_meets_audience_conditions, reasons = Optimizely::Audience.user_meets_audience_conditions?(config, experiment, user_attributes, spy_logger)
     expect(user_meets_audience_conditions).to be true
-    expect(reasons).to  eq(["Evaluating audiences for experiment 'test_experiment': [].", "Audiences for experiment 'test_experiment' collectively evaluated to TRUE."])
+    expect(reasons).to  eq(["Audiences for experiment 'test_experiment' collectively evaluated to TRUE."])
 
     # Audience Ids is Empty and  Audience Conditions is nil
     experiment = config.experiment_key_map['test_experiment']
@@ -52,7 +52,7 @@ describe Optimizely::Audience do
 
     user_meets_audience_conditions, reasons = Optimizely::Audience.user_meets_audience_conditions?(config, experiment, user_attributes, spy_logger)
     expect(user_meets_audience_conditions).to be true
-    expect(reasons).to eq(["Evaluating audiences for experiment 'test_experiment': [].", "Audiences for experiment 'test_experiment' collectively evaluated to TRUE."])
+    expect(reasons).to eq(["Audiences for experiment 'test_experiment' collectively evaluated to TRUE."])
   end
 
   it 'should pass conditions when audience conditions exist else audienceIds are passed' do
@@ -86,7 +86,6 @@ describe Optimizely::Audience do
     user_meets_audience_conditions, reasons = Optimizely::Audience.user_meets_audience_conditions?(config, experiment, {}, spy_logger)
     expect(user_meets_audience_conditions).to be false
     expect(reasons).to eq([
-                            "Evaluating audiences for experiment 'test_experiment_with_audience': [\"11154\"].",
                             "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
                             "Audience '11154' evaluated to UNKNOWN.",
                             "Audiences for experiment 'test_experiment_with_audience' collectively evaluated to FALSE."
@@ -96,7 +95,6 @@ describe Optimizely::Audience do
     user_meets_audience_conditions, reasons = Optimizely::Audience.user_meets_audience_conditions?(config, experiment, nil, spy_logger)
     expect(user_meets_audience_conditions).to be false
     expect(reasons).to eq([
-                            "Evaluating audiences for experiment 'test_experiment_with_audience': [\"11154\"].",
                             "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
                             "Audience '11154' evaluated to UNKNOWN.",
                             "Audiences for experiment 'test_experiment_with_audience' collectively evaluated to FALSE."
@@ -115,7 +113,6 @@ describe Optimizely::Audience do
     user_meets_audience_conditions, reasons = Optimizely::Audience.user_meets_audience_conditions?(config, experiment, user_attributes, spy_logger)
     expect(user_meets_audience_conditions).to be true
     expect(reasons).to eq([
-                            "Evaluating audiences for experiment 'test_experiment': [].",
                             "Audiences for experiment 'test_experiment' collectively evaluated to TRUE."
                           ])
   end
@@ -132,7 +129,6 @@ describe Optimizely::Audience do
     user_meets_audience_conditions, reasons = Optimizely::Audience.user_meets_audience_conditions?(config, experiment, user_attributes, spy_logger)
     expect(user_meets_audience_conditions).to be false
     expect(reasons).to eq([
-                            "Evaluating audiences for experiment 'test_experiment_with_audience': [\"11154\"].",
                             "Audiences for experiment 'test_experiment_with_audience' collectively evaluated to FALSE."
                           ])
 
@@ -141,7 +137,6 @@ describe Optimizely::Audience do
     user_meets_audience_conditions, reasons = Optimizely::Audience.user_meets_audience_conditions?(config, experiment, user_attributes, spy_logger)
     expect(user_meets_audience_conditions).to be false
     expect(reasons).to eq([
-                            "Evaluating audiences for experiment 'test_experiment_with_audience': [\"11154\"].",
                             "Audiences for experiment 'test_experiment_with_audience' collectively evaluated to FALSE."
                           ])
   end
@@ -231,7 +226,6 @@ describe Optimizely::Audience do
     user_meets_audience_conditions, reasons = Optimizely::Audience.user_meets_audience_conditions?(config, experiment, user_attributes, spy_logger)
     expect(user_meets_audience_conditions).to be false
     expect(reasons).to eq([
-                            "Evaluating audiences for experiment 'test_experiment_with_audience': [\"11110\"].",
                             "Audiences for experiment 'test_experiment_with_audience' collectively evaluated to FALSE."
                           ])
 
@@ -257,7 +251,6 @@ describe Optimizely::Audience do
     user_meets_audience_conditions, reasons = Optimizely::Audience.user_meets_audience_conditions?(config, experiment, user_attributes, spy_logger)
     expect(user_meets_audience_conditions).to be false
     expect(reasons).to eq([
-                            "Evaluating audiences for experiment 'test_experiment_with_audience': [\"11154\", \"11155\"].",
                             "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
                             "Audience '11154' evaluated to UNKNOWN.",
                             "Starting to evaluate audience '11155' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"chrome\"}]]].",

--- a/spec/bucketing_spec.rb
+++ b/spec/bucketing_spec.rb
@@ -85,7 +85,6 @@ describe Optimizely::Bucketer do
     variation_received, reasons = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
     expect(variation_received).to be_nil
     expect(reasons).to eq([
-                            "Assigned bucket 3000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.",
                             "User 'test_user' is not in experiment 'group1_exp2' of group 101."
                           ])
     expect(spy_logger).to have_received(:log)
@@ -112,7 +111,7 @@ describe Optimizely::Bucketer do
     expected_variation = config.get_variation_from_id('group2_exp1', '144443')
     variation_received, reasons = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
     expect(variation_received).to eq(expected_variation)
-    expect(reasons).to eq(["Assigned bucket 3000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'."])
+    expect(reasons).to eq([])
     expect(spy_logger).to have_received(:log).once
     expect(spy_logger).to have_received(:log)
       .with(Logger::DEBUG, "Assigned bucket 3000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
@@ -123,7 +122,7 @@ describe Optimizely::Bucketer do
 
     experiment = config.get_experiment_from_key('group2_exp1')
     variation_received, reasons = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
-    expect(reasons).to eq(["Assigned bucket 50000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'."])
+    expect(reasons).to eq([])
     expect(variation_received).to be_nil
     expect(spy_logger).to have_received(:log).once
     expect(spy_logger).to have_received(:log)
@@ -170,14 +169,14 @@ describe Optimizely::Bucketer do
       expected_variation = config.get_variation_from_id('test_experiment', '111128')
       variation_received, reasons = bucketer.bucket(config, experiment, 'test_user', 'test_user')
       expect(variation_received).to be(expected_variation)
-      expect(reasons).to eq(["Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'."])
+      expect(reasons).to eq([])
 
       # Bucketing with bucketing id - 'any_string789111127' produces bucket value btw 5000 to 10,000
       # thus buckets to variation
       expected_variation = config.get_variation_from_id('test_experiment', '111129')
       variation_received, reasons = bucketer.bucket(config, experiment, 'any_string789', 'test_user')
       expect(variation_received).to be(expected_variation)
-      expect(reasons).to eq(["Assigned bucket 9941 to user 'test_user' with bucketing ID: 'any_string789'."])
+      expect(reasons).to eq([])
     end
 
     # Bucketing with invalid experiment key and bucketing ID
@@ -196,14 +195,12 @@ describe Optimizely::Bucketer do
       variation_received, reasons = bucketer.bucket(config, experiment, 'test_user', 'test_user')
       expect(variation_received).to be(expected_variation)
       expect(reasons).to eq([
-                              "Assigned bucket 7543 to user 'test_user' with bucketing ID: 'test_user'.",
                               "User 'test_user' is not in experiment 'group1_exp1' of group 101."
                             ])
       expected_variation = config.get_variation_from_id('group1_exp1', '130002')
       variation_received, = bucketer.bucket(config, experiment, '123456789', 'test_user')
       expect(variation_received).to be(expected_variation)
       expect(reasons).to eq([
-                              "Assigned bucket 7543 to user 'test_user' with bucketing ID: 'test_user'.",
                               "User 'test_user' is not in experiment 'group1_exp1' of group 101."
                             ])
     end

--- a/spec/bucketing_spec.rb
+++ b/spec/bucketing_spec.rb
@@ -40,17 +40,17 @@ describe Optimizely::Bucketer do
 
     # Variation 1
     expected_variation_1 = config.get_variation_from_id('test_experiment', '111128')
-    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
-    expect(variation_recieved).to eq(expected_variation_1)
+    variation_received, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_received).to eq(expected_variation_1)
 
     # Variation 2
     expected_variation_2 = config.get_variation_from_id('test_experiment', '111129')
-    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
-    expect(variation_recieved).to eq(expected_variation_2)
+    variation_received, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_received).to eq(expected_variation_2)
 
     # No matching variation
-    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
-    expect(variation_recieved).to be_nil
+    variation_received, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_received).to be_nil
   end
 
   it 'should test the output of generate_bucket_value for different inputs' do
@@ -69,8 +69,8 @@ describe Optimizely::Bucketer do
 
     experiment = config.get_experiment_from_key('group1_exp1')
     expected_variation = config.get_variation_from_id('group1_exp1', '130001')
-    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
-    expect(variation_recieved).to eq(expected_variation)
+    variation_received, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_received).to eq(expected_variation)
     expect(spy_logger).to have_received(:log).exactly(3).times
     expect(spy_logger).to have_received(:log).twice
                                              .with(Logger::DEBUG, "Assigned bucket 3000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
@@ -82,8 +82,8 @@ describe Optimizely::Bucketer do
     expect(bucketer).to receive(:generate_bucket_value).once.and_return(3000)
 
     experiment = config.get_experiment_from_key('group1_exp2')
-    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
-    expect(variation_recieved).to be_nil
+    variation_received, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_received).to be_nil
     expect(spy_logger).to have_received(:log)
       .with(Logger::DEBUG, "Assigned bucket 3000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
     expect(spy_logger).to have_received(:log)
@@ -94,8 +94,8 @@ describe Optimizely::Bucketer do
     expect(bucketer).to receive(:find_bucket).once.and_return(nil)
 
     experiment = config.get_experiment_from_key('group1_exp2')
-    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
-    expect(variation_recieved).to be_nil
+    variation_received, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_received).to be_nil
     expect(spy_logger).to have_received(:log)
       .with(Logger::INFO, "User 'test_user' is in no experiment.")
   end
@@ -105,8 +105,8 @@ describe Optimizely::Bucketer do
 
     experiment = config.get_experiment_from_key('group2_exp1')
     expected_variation = config.get_variation_from_id('group2_exp1', '144443')
-    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
-    expect(variation_recieved).to eq(expected_variation)
+    variation_received, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_received).to eq(expected_variation)
     expect(spy_logger).to have_received(:log).once
     expect(spy_logger).to have_received(:log)
       .with(Logger::DEBUG, "Assigned bucket 3000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
@@ -116,8 +116,8 @@ describe Optimizely::Bucketer do
     expect(bucketer).to receive(:generate_bucket_value).and_return(50_000)
 
     experiment = config.get_experiment_from_key('group2_exp1')
-    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
-    expect(variation_recieved).to be_nil
+    variation_received, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_received).to be_nil
     expect(spy_logger).to have_received(:log).once
     expect(spy_logger).to have_received(:log)
       .with(Logger::DEBUG, "Assigned bucket 50000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
@@ -146,8 +146,8 @@ describe Optimizely::Bucketer do
   it 'should return nil when user is in an empty traffic allocation range due to sticky bucketing' do
     expect(bucketer).to receive(:find_bucket).once.and_return('')
     experiment = config.get_experiment_from_key('test_experiment')
-    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
-    expect(variation_recieved).to be_nil
+    variation_received, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_received).to be_nil
     expect(spy_logger).to have_received(:log)
       .with(Logger::DEBUG, 'Bucketed into an empty traffic range. Returning nil.')
   end
@@ -160,20 +160,20 @@ describe Optimizely::Bucketer do
 
       # Bucketing with user id as bucketing id - 'test_user111127' produces bucket value < 5000 thus buckets to control
       expected_variation = config.get_variation_from_id('test_experiment', '111128')
-      variation_recieved, = bucketer.bucket(config, experiment, 'test_user', 'test_user')
-      expect(variation_recieved).to be(expected_variation)
+      variation_received, = bucketer.bucket(config, experiment, 'test_user', 'test_user')
+      expect(variation_received).to be(expected_variation)
 
       # Bucketing with bucketing id - 'any_string789111127' produces bucket value btw 5000 to 10,000
       # thus buckets to variation
       expected_variation = config.get_variation_from_id('test_experiment', '111129')
-      variation_recieved, = bucketer.bucket(config, experiment, 'any_string789', 'test_user')
-      expect(variation_recieved).to be(expected_variation)
+      variation_received, = bucketer.bucket(config, experiment, 'any_string789', 'test_user')
+      expect(variation_received).to be(expected_variation)
     end
 
     # Bucketing with invalid experiment key and bucketing ID
     it 'should return nil with invalid experiment and bucketing ID' do
-      variation_recieved, = bucketer.bucket(config, config.get_experiment_from_key('invalid_experiment'), 'some_id', 'test_user')
-      expect(variation_recieved).to be(nil)
+      variation_received, = bucketer.bucket(config, config.get_experiment_from_key('invalid_experiment'), 'some_id', 'test_user')
+      expect(variation_received).to be(nil)
     end
 
     # Bucketing with grouped experiments and bucketing ID
@@ -182,12 +182,12 @@ describe Optimizely::Bucketer do
       experiment = config.get_experiment_from_key('group1_exp1')
 
       expected_variation = nil
-      variation_recieved, = bucketer.bucket(config, experiment, 'test_user', 'test_user')
-      expect(variation_recieved).to be(expected_variation)
+      variation_received, = bucketer.bucket(config, experiment, 'test_user', 'test_user')
+      expect(variation_received).to be(expected_variation)
 
       expected_variation = config.get_variation_from_id('group1_exp1', '130002')
-      variation_recieved, = bucketer.bucket(config, experiment, '123456789', 'test_user')
-      expect(variation_recieved).to be(expected_variation)
+      variation_received, = bucketer.bucket(config, experiment, '123456789', 'test_user')
+      expect(variation_received).to be(expected_variation)
     end
   end
 

--- a/spec/bucketing_spec.rb
+++ b/spec/bucketing_spec.rb
@@ -40,14 +40,17 @@ describe Optimizely::Bucketer do
 
     # Variation 1
     expected_variation_1 = config.get_variation_from_id('test_experiment', '111128')
-    expect(bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')).to eq(expected_variation_1)
+    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_recieved).to eq(expected_variation_1)
 
     # Variation 2
     expected_variation_2 = config.get_variation_from_id('test_experiment', '111129')
-    expect(bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')).to eq(expected_variation_2)
+    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_recieved).to eq(expected_variation_2)
 
     # No matching variation
-    expect(bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')).to be_nil
+    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_recieved).to be_nil
   end
 
   it 'should test the output of generate_bucket_value for different inputs' do
@@ -66,7 +69,8 @@ describe Optimizely::Bucketer do
 
     experiment = config.get_experiment_from_key('group1_exp1')
     expected_variation = config.get_variation_from_id('group1_exp1', '130001')
-    expect(bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')).to eq(expected_variation)
+    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_recieved).to eq(expected_variation)
     expect(spy_logger).to have_received(:log).exactly(3).times
     expect(spy_logger).to have_received(:log).twice
                                              .with(Logger::DEBUG, "Assigned bucket 3000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
@@ -78,7 +82,8 @@ describe Optimizely::Bucketer do
     expect(bucketer).to receive(:generate_bucket_value).once.and_return(3000)
 
     experiment = config.get_experiment_from_key('group1_exp2')
-    expect(bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')).to be_nil
+    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_recieved).to be_nil
     expect(spy_logger).to have_received(:log)
       .with(Logger::DEBUG, "Assigned bucket 3000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
     expect(spy_logger).to have_received(:log)
@@ -89,7 +94,8 @@ describe Optimizely::Bucketer do
     expect(bucketer).to receive(:find_bucket).once.and_return(nil)
 
     experiment = config.get_experiment_from_key('group1_exp2')
-    expect(bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')).to be_nil
+    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_recieved).to be_nil
     expect(spy_logger).to have_received(:log)
       .with(Logger::INFO, "User 'test_user' is in no experiment.")
   end
@@ -99,7 +105,8 @@ describe Optimizely::Bucketer do
 
     experiment = config.get_experiment_from_key('group2_exp1')
     expected_variation = config.get_variation_from_id('group2_exp1', '144443')
-    expect(bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')).to eq(expected_variation)
+    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_recieved).to eq(expected_variation)
     expect(spy_logger).to have_received(:log).once
     expect(spy_logger).to have_received(:log)
       .with(Logger::DEBUG, "Assigned bucket 3000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
@@ -109,7 +116,8 @@ describe Optimizely::Bucketer do
     expect(bucketer).to receive(:generate_bucket_value).and_return(50_000)
 
     experiment = config.get_experiment_from_key('group2_exp1')
-    expect(bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')).to be_nil
+    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_recieved).to be_nil
     expect(spy_logger).to have_received(:log).once
     expect(spy_logger).to have_received(:log)
       .with(Logger::DEBUG, "Assigned bucket 50000 to user 'test_user' with bucketing ID: 'bucket_id_ignored'.")
@@ -138,7 +146,8 @@ describe Optimizely::Bucketer do
   it 'should return nil when user is in an empty traffic allocation range due to sticky bucketing' do
     expect(bucketer).to receive(:find_bucket).once.and_return('')
     experiment = config.get_experiment_from_key('test_experiment')
-    expect(bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')).to be_nil
+    variation_recieved, = bucketer.bucket(config, experiment, 'bucket_id_ignored', 'test_user')
+    expect(variation_recieved).to be_nil
     expect(spy_logger).to have_received(:log)
       .with(Logger::DEBUG, 'Bucketed into an empty traffic range. Returning nil.')
   end
@@ -151,17 +160,20 @@ describe Optimizely::Bucketer do
 
       # Bucketing with user id as bucketing id - 'test_user111127' produces bucket value < 5000 thus buckets to control
       expected_variation = config.get_variation_from_id('test_experiment', '111128')
-      expect(bucketer.bucket(config, experiment, 'test_user', 'test_user')).to be(expected_variation)
+      variation_recieved, = bucketer.bucket(config, experiment, 'test_user', 'test_user')
+      expect(variation_recieved).to be(expected_variation)
 
       # Bucketing with bucketing id - 'any_string789111127' produces bucket value btw 5000 to 10,000
       # thus buckets to variation
       expected_variation = config.get_variation_from_id('test_experiment', '111129')
-      expect(bucketer.bucket(config, experiment, 'any_string789', 'test_user')).to be(expected_variation)
+      variation_recieved, = bucketer.bucket(config, experiment, 'any_string789', 'test_user')
+      expect(variation_recieved).to be(expected_variation)
     end
 
     # Bucketing with invalid experiment key and bucketing ID
     it 'should return nil with invalid experiment and bucketing ID' do
-      expect(bucketer.bucket(config, config.get_experiment_from_key('invalid_experiment'), 'some_id', 'test_user')).to be(nil)
+      variation_recieved, = bucketer.bucket(config, config.get_experiment_from_key('invalid_experiment'), 'some_id', 'test_user')
+      expect(variation_recieved).to be(nil)
     end
 
     # Bucketing with grouped experiments and bucketing ID
@@ -170,10 +182,12 @@ describe Optimizely::Bucketer do
       experiment = config.get_experiment_from_key('group1_exp1')
 
       expected_variation = nil
-      expect(bucketer.bucket(config, experiment, 'test_user', 'test_user')).to be(expected_variation)
+      variation_recieved, = bucketer.bucket(config, experiment, 'test_user', 'test_user')
+      expect(variation_recieved).to be(expected_variation)
 
       expected_variation = config.get_variation_from_id('group1_exp1', '130002')
-      expect(bucketer.bucket(config, experiment, '123456789', 'test_user')).to be(expected_variation)
+      variation_recieved, = bucketer.bucket(config, experiment, '123456789', 'test_user')
+      expect(variation_recieved).to be(expected_variation)
     end
   end
 

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -747,13 +747,15 @@ describe Optimizely::DecisionService do
 
     # User ID is not defined in the forced variation map
     it 'should log a message and return nil when user is not in forced variation map' do
-      expect(decision_service.get_forced_variation(config, valid_experiment[:key], user_id)).to eq(nil)
+      variation_received, = decision_service.get_forced_variation(config, valid_experiment[:key], user_id)
+      expect(variation_received).to eq(nil)
       expect(spy_logger).to have_received(:log).with(Logger::DEBUG,
                                                      "User '#{user_id}' is not in the forced variation map.")
     end
     # Experiment key does not exist in the datafile
     it 'should return nil when experiment key is not in datafile' do
-      expect(decision_service.get_forced_variation(config, invalid_experiment_key, user_id)).to eq(nil)
+      variation_received, = decision_service.get_forced_variation(config, invalid_experiment_key, user_id)
+      expect(variation_received).to eq(nil)
     end
   end
 
@@ -787,12 +789,12 @@ describe Optimizely::DecisionService do
     # Call set variation with different variations on one user/experiment to confirm that each set is expected.
     it 'should set and return expected variations when different variations are set and removed for one user/experiment' do
       expect(decision_service.set_forced_variation(config, valid_experiment[:key], user_id, valid_variation[:key])).to eq(true)
-      variation = decision_service.get_forced_variation(config, valid_experiment[:key], user_id)
+      variation, = decision_service.get_forced_variation(config, valid_experiment[:key], user_id)
       expect(variation['id']).to eq(valid_variation[:id])
       expect(variation['key']).to eq(valid_variation[:key])
 
       expect(decision_service.set_forced_variation(config, valid_experiment[:key], user_id, valid_variation_2[:key])).to eq(true)
-      variation = decision_service.get_forced_variation(config, valid_experiment[:key], user_id)
+      variation, = decision_service.get_forced_variation(config, valid_experiment[:key], user_id)
       expect(variation['id']).to eq(valid_variation_2[:id])
       expect(variation['key']).to eq(valid_variation_2[:key])
     end
@@ -800,12 +802,12 @@ describe Optimizely::DecisionService do
     # Set variation on multiple experiments for one user.
     it 'should set and return expected variations when variation is set for multiple experiments for one user' do
       expect(decision_service.set_forced_variation(config, valid_experiment[:key], user_id, valid_variation[:key])).to eq(true)
-      variation = decision_service.get_forced_variation(config, valid_experiment[:key], user_id)
+      variation, = decision_service.get_forced_variation(config, valid_experiment[:key], user_id)
       expect(variation['id']).to eq(valid_variation[:id])
       expect(variation['key']).to eq(valid_variation[:key])
 
       expect(decision_service.set_forced_variation(config, valid_experiment_2[:key], user_id, valid_variation_for_exp_2[:key])).to eq(true)
-      variation = decision_service.get_forced_variation(config, valid_experiment_2[:key], user_id)
+      variation, = decision_service.get_forced_variation(config, valid_experiment_2[:key], user_id)
       expect(variation['id']).to eq(valid_variation_for_exp_2[:id])
       expect(variation['key']).to eq(valid_variation_for_exp_2[:key])
     end
@@ -813,12 +815,12 @@ describe Optimizely::DecisionService do
     # Set variations for multiple users.
     it 'should set and return expected variations when variations are set for multiple users' do
       expect(decision_service.set_forced_variation(config, valid_experiment[:key], user_id, valid_variation[:key])).to eq(true)
-      variation = decision_service.get_forced_variation(config, valid_experiment[:key], user_id)
+      variation, = decision_service.get_forced_variation(config, valid_experiment[:key], user_id)
       expect(variation['id']).to eq(valid_variation[:id])
       expect(variation['key']).to eq(valid_variation[:key])
 
       expect(decision_service.set_forced_variation(config, valid_experiment[:key], user_id_2, valid_variation[:key])).to eq(true)
-      variation = decision_service.get_forced_variation(config, valid_experiment[:key], user_id_2)
+      variation, = decision_service.get_forced_variation(config, valid_experiment[:key], user_id_2)
       expect(variation['id']).to eq(valid_variation[:id])
       expect(variation['key']).to eq(valid_variation[:key])
     end

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -71,7 +71,6 @@ describe Optimizely::DecisionService do
       expect(variation_received).to eq('111128')
 
       expect(reasons).to eq([
-                              "User 'test_user' is not in the forced variation map.",
                               "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                               "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                               "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
@@ -88,7 +87,6 @@ describe Optimizely::DecisionService do
       variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'test_user')
       expect(variation_received).to eq(nil)
       expect(reasons).to eq([
-                              "User 'test_user' is not in the forced variation map.",
                               "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                               "User 'test_user' is in no variation."
                             ])
@@ -101,7 +99,6 @@ describe Optimizely::DecisionService do
       variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'forced_user1')
       expect(variation_received).to eq('111128')
       expect(reasons).to eq([
-                              "User 'forced_user1' is not in the forced variation map.",
                               "User 'forced_user1' is whitelisted into variation 'control' of experiment 'test_experiment'."
                             ])
       expect(spy_logger).to have_received(:log)
@@ -110,7 +107,6 @@ describe Optimizely::DecisionService do
       variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'forced_user2')
       expect(variation_received).to eq('111129')
       expect(reasons).to eq([
-                              "User 'forced_user2' is not in the forced variation map.",
                               "User 'forced_user2' is whitelisted into variation 'variation' of experiment 'test_experiment'."
                             ])
       expect(spy_logger).to have_received(:log)
@@ -131,7 +127,6 @@ describe Optimizely::DecisionService do
       variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'forced_user1', user_attributes)
       expect(variation_received).to eq('111128')
       expect(reasons).to eq([
-                              "User 'forced_user1' is not in the forced variation map.",
                               "User 'forced_user1' is whitelisted into variation 'control' of experiment 'test_experiment'."
                             ])
       expect(spy_logger).to have_received(:log)
@@ -140,7 +135,6 @@ describe Optimizely::DecisionService do
       variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'forced_user2', user_attributes)
       expect(variation_received).to eq('111129')
       expect(reasons).to eq([
-                              "User 'forced_user2' is not in the forced variation map.",
                               "User 'forced_user2' is whitelisted into variation 'variation' of experiment 'test_experiment'."
                             ])
       expect(spy_logger).to have_received(:log)
@@ -157,7 +151,6 @@ describe Optimizely::DecisionService do
       variation_received, reasons = decision_service.get_variation(config, 'test_experiment_with_audience', 'forced_audience_user', user_attributes)
       expect(variation_received).to eq('122229')
       expect(reasons).to eq([
-                              "User 'forced_audience_user' is not in the forced variation map.",
                               "User 'forced_audience_user' is whitelisted into variation 'variation_with_audience' of experiment 'test_experiment_with_audience'."
                             ])
       expect(spy_logger).to have_received(:log)
@@ -186,7 +179,6 @@ describe Optimizely::DecisionService do
       variation_received, reasons = decision_service.get_variation(config, 'test_experiment_with_audience', 'test_user', user_attributes)
       expect(variation_received).to eq(nil)
       expect(reasons).to eq([
-                              "User 'test_user' is not in the forced variation map.",
                               "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
                               "Audience '11154' evaluated to FALSE.",
                               "Audiences for experiment 'test_experiment_with_audience' collectively evaluated to FALSE.",
@@ -220,7 +212,6 @@ describe Optimizely::DecisionService do
       variation_received, reasons = decision_service.get_variation(config, 'group1_exp2', 'forced_group_user1')
       expect(variation_received).to eq('130004')
       expect(reasons).to eq([
-                              "User 'forced_group_user1' is not in the forced variation map.",
                               "User 'forced_group_user1' is whitelisted into variation 'g1_e2_v2' of experiment 'group1_exp2'."
                             ])
       expect(spy_logger).to have_received(:log)
@@ -236,7 +227,6 @@ describe Optimizely::DecisionService do
       variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'forced_user_with_invalid_variation')
       expect(variation_received).to eq('111128')
       expect(reasons).to eq([
-                              "User 'forced_user_with_invalid_variation' is not in the forced variation map.",
                               "User 'forced_user_with_invalid_variation' is whitelisted into variation 'invalid_variation', which is not in the datafile.",
                               "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                               "Assigned bucket 877 to user 'forced_user_with_invalid_variation' with bucketing ID: 'forced_user_with_invalid_variation'.",
@@ -268,7 +258,6 @@ describe Optimizely::DecisionService do
         variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'test_user')
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
-                                "User 'test_user' is not in the forced variation map.",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
@@ -300,7 +289,6 @@ describe Optimizely::DecisionService do
         variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'test_user', user_attributes)
         expect(variation_received).to eq('111129')
         expect(reasons).to eq([
-                                "User 'test_user' is not in the forced variation map.",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 8933 to user 'test_user' with bucketing ID: 'pid'.",
                                 "User 'test_user' is in variation 'variation' of experiment 'test_experiment'."
@@ -329,7 +317,6 @@ describe Optimizely::DecisionService do
         variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'test_user')
         expect(variation_received).to eq('111129')
         expect(reasons).to eq([
-                                "User 'test_user' is not in the forced variation map.",
                                 "Returning previously activated variation ID 111129 of experiment 'test_experiment' for user 'test_user' from user profile."
                               ])
         expect(spy_logger).to have_received(:log).once
@@ -359,7 +346,6 @@ describe Optimizely::DecisionService do
         variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'test_user')
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
-                                "User 'test_user' is not in the forced variation map.",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
@@ -399,7 +385,6 @@ describe Optimizely::DecisionService do
         variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'test_user')
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
-                                "User 'test_user' is not in the forced variation map.",
                                 "User '' was previously bucketed into variation ID '111111' for experiment '111127', but no matching variation was found. Re-bucketing user.",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
@@ -427,7 +412,6 @@ describe Optimizely::DecisionService do
         variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'test_user')
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
-                                "User 'test_user' is not in the forced variation map.",
                                 "Error while looking up user profile for user ID 'test_user': uncaught throw :LookupError.",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
@@ -446,7 +430,6 @@ describe Optimizely::DecisionService do
         variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'test_user')
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
-                                "User 'test_user' is not in the forced variation map.",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
@@ -464,7 +447,6 @@ describe Optimizely::DecisionService do
           variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'test_user', nil, [Optimizely::Decide::OptimizelyDecideOption::IGNORE_USER_PROFILE_SERVICE])
           expect(variation_received).to eq('111128')
           expect(reasons).to eq([
-                                  "User 'test_user' is not in the forced variation map.",
                                   "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                   "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                   "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
@@ -483,7 +465,6 @@ describe Optimizely::DecisionService do
           variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'test_user')
           expect(variation_received).to eq('111128')
           expect(reasons).to eq([
-                                  "User 'test_user' is not in the forced variation map.",
                                   "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                   "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                   "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
@@ -915,7 +896,7 @@ describe Optimizely::DecisionService do
     it 'should log a message and return nil when user is not in forced variation map' do
       variation_received, reasons = decision_service.get_forced_variation(config, valid_experiment[:key], user_id)
       expect(variation_received).to eq(nil)
-      expect(reasons).to eq(["User '#{user_id}' is not in the forced variation map."])
+      expect(reasons).to eq([])
       expect(spy_logger).to have_received(:log).with(Logger::DEBUG,
                                                      "User '#{user_id}' is not in the forced variation map.")
     end
@@ -923,7 +904,7 @@ describe Optimizely::DecisionService do
     it 'should return nil when experiment key is not in datafile' do
       variation_received, reasons = decision_service.get_forced_variation(config, invalid_experiment_key, user_id)
       expect(variation_received).to eq(nil)
-      expect(reasons).to eq(["User 'test_user' is not in the forced variation map."])
+      expect(reasons).to eq([])
     end
   end
 

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -72,7 +72,6 @@ describe Optimizely::DecisionService do
 
       expect(reasons).to eq([
                               "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
-                              "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                               "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                             ])
 
@@ -229,7 +228,6 @@ describe Optimizely::DecisionService do
       expect(reasons).to eq([
                               "User 'forced_user_with_invalid_variation' is whitelisted into variation 'invalid_variation', which is not in the datafile.",
                               "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
-                              "Assigned bucket 877 to user 'forced_user_with_invalid_variation' with bucketing ID: 'forced_user_with_invalid_variation'.",
                               "User 'forced_user_with_invalid_variation' is in variation 'control' of experiment 'test_experiment'."
                             ])
       expect(spy_logger).to have_received(:log)
@@ -259,7 +257,6 @@ describe Optimizely::DecisionService do
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
-                                "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                               ])
 
@@ -290,7 +287,6 @@ describe Optimizely::DecisionService do
         expect(variation_received).to eq('111129')
         expect(reasons).to eq([
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
-                                "Assigned bucket 8933 to user 'test_user' with bucketing ID: 'pid'.",
                                 "User 'test_user' is in variation 'variation' of experiment 'test_experiment'."
                               ])
 
@@ -347,7 +343,6 @@ describe Optimizely::DecisionService do
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
-                                "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                               ])
 
@@ -387,7 +382,6 @@ describe Optimizely::DecisionService do
         expect(reasons).to eq([
                                 "User '' was previously bucketed into variation ID '111111' for experiment '111127', but no matching variation was found. Re-bucketing user.",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
-                                "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                               ])
 
@@ -414,7 +408,6 @@ describe Optimizely::DecisionService do
         expect(reasons).to eq([
                                 "Error while looking up user profile for user ID 'test_user': uncaught throw :LookupError.",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
-                                "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                               ])
 
@@ -431,7 +424,6 @@ describe Optimizely::DecisionService do
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
-                                "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                               ])
 
@@ -448,7 +440,6 @@ describe Optimizely::DecisionService do
           expect(variation_received).to eq('111128')
           expect(reasons).to eq([
                                   "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
-                                  "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                   "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                                 ])
 
@@ -466,7 +457,6 @@ describe Optimizely::DecisionService do
           expect(variation_received).to eq('111128')
           expect(reasons).to eq([
                                   "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
-                                  "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                   "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                                 ])
 

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -691,9 +691,10 @@ describe Optimizely::DecisionService do
           'experiment' => expected_experiment,
           'variation' => expected_variation
         }
-        allow(decision_service).to receive(:get_variation_for_feature_experiment).and_return(expected_decision)
+        allow(decision_service).to receive(:get_variation_for_feature_experiment).and_return([expected_decision, nil])
 
-        expect(decision_service.get_variation_for_feature(config, feature_flag, user_id, user_attributes)).to eq(expected_decision)
+        decision_received, = decision_service.get_variation_for_feature(config, feature_flag, user_id, user_attributes)
+        expect(decision_received).to eq(expected_decision)
       end
     end
 
@@ -708,20 +709,22 @@ describe Optimizely::DecisionService do
             variation,
             Optimizely::DecisionService::DECISION_SOURCES['ROLLOUT']
           )
-          allow(decision_service).to receive(:get_variation_for_feature_experiment).and_return(nil)
-          allow(decision_service).to receive(:get_variation_for_feature_rollout).and_return(expected_decision)
+          allow(decision_service).to receive(:get_variation_for_feature_experiment).and_return([nil, nil])
+          allow(decision_service).to receive(:get_variation_for_feature_rollout).and_return([expected_decision, nil])
 
-          expect(decision_service.get_variation_for_feature(config, feature_flag, user_id, user_attributes)).to eq(expected_decision)
+          decision_received, = decision_service.get_variation_for_feature(config, feature_flag, user_id, user_attributes)
+          expect(decision_received).to eq(expected_decision)
         end
       end
 
       describe 'and the user is not bucketed into the feature rollout' do
         it 'should log a message and return nil' do
           feature_flag = config.feature_flag_key_map['string_single_variable_feature']
-          allow(decision_service).to receive(:get_variation_for_feature_experiment).and_return(nil)
-          allow(decision_service).to receive(:get_variation_for_feature_rollout).and_return(nil)
+          allow(decision_service).to receive(:get_variation_for_feature_experiment).and_return([nil, nil])
+          allow(decision_service).to receive(:get_variation_for_feature_rollout).and_return([nil, nil])
 
-          expect(decision_service.get_variation_for_feature(config, feature_flag, user_id, user_attributes)).to eq(nil)
+          decision_received, = decision_service.get_variation_for_feature(config, feature_flag, user_id, user_attributes)
+          expect(decision_received).to eq(nil)
         end
       end
     end

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -181,7 +181,7 @@ describe Optimizely::DecisionService do
       # bucketing should have occured
       experiment = config.get_experiment_from_key('test_experiment')
       # since we do not pass bucketing id attribute, bucketer will recieve user id as the bucketing id
-      expect(decision_service.bucketer).to have_received(:bucket).once.with(config, experiment, 'forced_user_with_invalid_variation', 'forced_user_with_invalid_variation', nil)
+      expect(decision_service.bucketer).to have_received(:bucket).once.with(config, experiment, 'forced_user_with_invalid_variation', 'forced_user_with_invalid_variation')
     end
 
     describe 'when a UserProfile service is provided' do
@@ -519,7 +519,7 @@ describe Optimizely::DecisionService do
           expected_decision = Optimizely::DecisionService::Decision.new(rollout_experiment, variation, Optimizely::DecisionService::DECISION_SOURCES['ROLLOUT'])
           allow(Optimizely::Audience).to receive(:user_meets_audience_conditions?).and_return(true)
           allow(decision_service.bucketer).to receive(:bucket)
-            .with(config, rollout_experiment, user_id, user_id, nil)
+            .with(config, rollout_experiment, user_id, user_id)
             .and_return(variation)
           expect(decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes, nil)).to eq(expected_decision)
         end
@@ -534,10 +534,10 @@ describe Optimizely::DecisionService do
 
             allow(Optimizely::Audience).to receive(:user_meets_audience_conditions?).and_return(true)
             allow(decision_service.bucketer).to receive(:bucket)
-              .with(config, rollout['experiments'][0], user_id, user_id, nil)
+              .with(config, rollout['experiments'][0], user_id, user_id)
               .and_return(nil)
             allow(decision_service.bucketer).to receive(:bucket)
-              .with(config, everyone_else_experiment, user_id, user_id, nil)
+              .with(config, everyone_else_experiment, user_id, user_id)
               .and_return(nil)
 
             expect(decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes, nil)).to eq(nil)
@@ -559,10 +559,10 @@ describe Optimizely::DecisionService do
             expected_decision = Optimizely::DecisionService::Decision.new(everyone_else_experiment, variation, Optimizely::DecisionService::DECISION_SOURCES['ROLLOUT'])
             allow(Optimizely::Audience).to receive(:user_meets_audience_conditions?).and_return(true)
             allow(decision_service.bucketer).to receive(:bucket)
-              .with(config, rollout['experiments'][0], user_id, user_id, nil)
+              .with(config, rollout['experiments'][0], user_id, user_id)
               .and_return(nil)
             allow(decision_service.bucketer).to receive(:bucket)
-              .with(config, everyone_else_experiment, user_id, user_id, nil)
+              .with(config, everyone_else_experiment, user_id, user_id)
               .and_return(variation)
 
             expect(decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes, nil)).to eq(expected_decision)
@@ -590,7 +590,7 @@ describe Optimizely::DecisionService do
           .with(config, everyone_else_experiment, user_attributes, spy_logger, 'ROLLOUT_AUDIENCE_EVALUATION_LOGS', 'Everyone Else')
           .and_return(true)
         allow(decision_service.bucketer).to receive(:bucket)
-          .with(config, everyone_else_experiment, user_id, user_id, nil)
+          .with(config, everyone_else_experiment, user_id, user_id)
           .and_return(variation)
 
         expect(decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes, nil)).to eq(expected_decision)

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -380,7 +380,7 @@ describe Optimizely::DecisionService do
         variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'test_user')
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
-                                "User '' was previously bucketed into variation ID '111111' for experiment '111127', but no matching variation was found. Re-bucketing user.",
+                                "User 'test_user' was previously bucketed into variation ID '111111' for experiment '111127', but no matching variation was found. Re-bucketing user.",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                               ])

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -69,8 +69,11 @@ describe Optimizely::DecisionService do
     it 'should return the correct variation ID for a given user ID and key of a running experiment' do
       variation_received, reasons = decision_service.get_variation(config, 'test_experiment', 'test_user')
       expect(variation_received).to eq('111128')
+
       expect(reasons).to eq([
                               "User 'test_user' is not in the forced variation map.",
+                              "Evaluating audiences for experiment 'test_experiment': [].",
+                              "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                               "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                               "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                             ])
@@ -87,6 +90,8 @@ describe Optimizely::DecisionService do
       expect(variation_received).to eq(nil)
       expect(reasons).to eq([
                               "User 'test_user' is not in the forced variation map.",
+                              "Evaluating audiences for experiment 'test_experiment': [].",
+                              "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                               "User 'test_user' is in no variation."
                             ])
 
@@ -184,6 +189,10 @@ describe Optimizely::DecisionService do
       expect(variation_received).to eq(nil)
       expect(reasons).to eq([
                               "User 'test_user' is not in the forced variation map.",
+                              "Evaluating audiences for experiment 'test_experiment_with_audience': [\"11154\"].",
+                              "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
+                              "Audience '11154' evaluated to FALSE.",
+                              "Audiences for experiment 'test_experiment_with_audience' collectively evaluated to FALSE.",
                               "User 'test_user' does not meet the conditions to be in experiment 'test_experiment_with_audience'."
                             ])
       expect(spy_logger).to have_received(:log)
@@ -232,6 +241,8 @@ describe Optimizely::DecisionService do
       expect(reasons).to eq([
                               "User 'forced_user_with_invalid_variation' is not in the forced variation map.",
                               "User 'forced_user_with_invalid_variation' is whitelisted into variation 'invalid_variation', which is not in the datafile.",
+                              "Evaluating audiences for experiment 'test_experiment': [].",
+                              "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                               "Assigned bucket 877 to user 'forced_user_with_invalid_variation' with bucketing ID: 'forced_user_with_invalid_variation'.",
                               "User 'forced_user_with_invalid_variation' is in variation 'control' of experiment 'test_experiment'."
                             ])
@@ -262,6 +273,8 @@ describe Optimizely::DecisionService do
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
                                 "User 'test_user' is not in the forced variation map.",
+                                "Evaluating audiences for experiment 'test_experiment': [].",
+                                "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                               ])
@@ -293,6 +306,8 @@ describe Optimizely::DecisionService do
         expect(variation_received).to eq('111129')
         expect(reasons).to eq([
                                 "User 'test_user' is not in the forced variation map.",
+                                "Evaluating audiences for experiment 'test_experiment': [].",
+                                "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 8933 to user 'test_user' with bucketing ID: 'pid'.",
                                 "User 'test_user' is in variation 'variation' of experiment 'test_experiment'."
                               ])
@@ -351,6 +366,8 @@ describe Optimizely::DecisionService do
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
                                 "User 'test_user' is not in the forced variation map.",
+                                "Evaluating audiences for experiment 'test_experiment': [].",
+                                "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                               ])
@@ -391,6 +408,8 @@ describe Optimizely::DecisionService do
         expect(reasons).to eq([
                                 "User 'test_user' is not in the forced variation map.",
                                 "User '' was previously bucketed into variation ID '111111' for experiment '111127', but no matching variation was found. Re-bucketing user.",
+                                "Evaluating audiences for experiment 'test_experiment': [].",
+                                "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                               ])
@@ -418,6 +437,8 @@ describe Optimizely::DecisionService do
         expect(reasons).to eq([
                                 "User 'test_user' is not in the forced variation map.",
                                 "Error while looking up user profile for user ID 'test_user': uncaught throw :LookupError.",
+                                "Evaluating audiences for experiment 'test_experiment': [].",
+                                "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                               ])
@@ -435,6 +456,8 @@ describe Optimizely::DecisionService do
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
                                 "User 'test_user' is not in the forced variation map.",
+                                "Evaluating audiences for experiment 'test_experiment': [].",
+                                "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                               ])
@@ -452,6 +475,8 @@ describe Optimizely::DecisionService do
           expect(variation_received).to eq('111128')
           expect(reasons).to eq([
                                   "User 'test_user' is not in the forced variation map.",
+                                  "Evaluating audiences for experiment 'test_experiment': [].",
+                                  "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                   "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                   "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                                 ])
@@ -470,6 +495,8 @@ describe Optimizely::DecisionService do
           expect(variation_received).to eq('111128')
           expect(reasons).to eq([
                                   "User 'test_user' is not in the forced variation map.",
+                                  "Evaluating audiences for experiment 'test_experiment': [].",
+                                  "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                   "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                   "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
                                 ])

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -482,8 +482,8 @@ describe Optimizely::DecisionService do
     describe 'when the feature flag is not associated with a rollout' do
       it 'should log a message and return nil' do
         feature_flag = config.feature_flag_key_map['boolean_feature']
-        expect(decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes)).to eq(nil)
-
+        variation_received, = decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes)
+        expect(variation_received).to eq(nil)
         expect(spy_logger).to have_received(:log).once
                                                  .with(Logger::DEBUG, "Feature flag '#{feature_flag['key']}' is not used in a rollout.")
       end
@@ -493,7 +493,8 @@ describe Optimizely::DecisionService do
       it 'should log a message and return nil' do
         feature_flag = config.feature_flag_key_map['boolean_feature'].dup
         feature_flag['rolloutId'] = 'invalid_rollout_id'
-        expect(decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes)).to eq(nil)
+        variation_received, = decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes)
+        expect(variation_received).to eq(nil)
 
         expect(spy_logger).to have_received(:log).once
                                                  .with(Logger::ERROR, "Rollout with ID 'invalid_rollout_id' is not in the datafile.")
@@ -506,7 +507,8 @@ describe Optimizely::DecisionService do
         experimentless_rollout['experiments'] = []
         allow(config).to receive(:get_rollout_from_id).and_return(experimentless_rollout)
         feature_flag = config.feature_flag_key_map['boolean_single_variable_feature']
-        expect(decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes)).to eq(nil)
+        variation_received, = decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes)
+        expect(variation_received).to eq(nil)
       end
     end
 
@@ -521,7 +523,8 @@ describe Optimizely::DecisionService do
           allow(decision_service.bucketer).to receive(:bucket)
             .with(config, rollout_experiment, user_id, user_id)
             .and_return(variation)
-          expect(decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes, nil)).to eq(expected_decision)
+          variation_received, = decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes)
+          expect(variation_received).to eq(expected_decision)
         end
       end
 
@@ -540,7 +543,8 @@ describe Optimizely::DecisionService do
               .with(config, everyone_else_experiment, user_id, user_id)
               .and_return(nil)
 
-            expect(decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes, nil)).to eq(nil)
+            variation_received, = decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes)
+            expect(variation_received).to eq(nil)
 
             # make sure we only checked the audience for the first rule
             expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?).once
@@ -565,7 +569,8 @@ describe Optimizely::DecisionService do
               .with(config, everyone_else_experiment, user_id, user_id)
               .and_return(variation)
 
-            expect(decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes, nil)).to eq(expected_decision)
+            variation_received, = decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes)
+            expect(variation_received).to eq(expected_decision)
 
             # make sure we only checked the audience for the first rule
             expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?).once
@@ -593,7 +598,8 @@ describe Optimizely::DecisionService do
           .with(config, everyone_else_experiment, user_id, user_id)
           .and_return(variation)
 
-        expect(decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes, nil)).to eq(expected_decision)
+        variation_received, = decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes)
+        expect(variation_received).to eq(expected_decision)
 
         # verify we tried to bucket in all targeting rules and the everyone else rule
         expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?)
@@ -621,7 +627,8 @@ describe Optimizely::DecisionService do
         expect(decision_service.bucketer).not_to receive(:bucket)
           .with(config, everyone_else_experiment, user_id, user_id)
 
-        expect(decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes)).to eq(nil)
+        variation_received, = decision_service.get_variation_for_feature_rollout(config, feature_flag, user_id, user_attributes)
+        expect(variation_received).to eq(nil)
 
         # verify we tried to bucket in all targeting rules and the everyone else rule
         expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?).once

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -42,7 +42,8 @@ describe Optimizely::DecisionService do
 
     it 'should return the correct variation ID for a given user for whom a variation has been forced' do
       decision_service.set_forced_variation(config, 'test_experiment', 'test_user', 'variation')
-      expect(decision_service.get_variation(config, 'test_experiment', 'test_user')).to eq('111129')
+      variation_received, = decision_service.get_variation(config, 'test_experiment', 'test_user')
+      expect(variation_received).to eq('111129')
       # Setting forced variation should short circuit whitelist check, bucketing and audience evaluation
       expect(decision_service).not_to have_received(:get_whitelisted_variation_id)
       expect(decision_service.bucketer).not_to have_received(:bucket)
@@ -55,7 +56,8 @@ describe Optimizely::DecisionService do
         Optimizely::Helpers::Constants::CONTROL_ATTRIBUTES['BUCKETING_ID'] => 'pid'
       }
       decision_service.set_forced_variation(config, 'test_experiment_with_audience', 'test_user', 'control_with_audience')
-      expect(decision_service.get_variation(config, 'test_experiment_with_audience', 'test_user', user_attributes)).to eq('122228')
+      variation_received, = decision_service.get_variation(config, 'test_experiment_with_audience', 'test_user', user_attributes)
+      expect(variation_received).to eq('122228')
       # Setting forced variation should short circuit whitelist check, bucketing and audience evaluation
       expect(decision_service).not_to have_received(:get_whitelisted_variation_id)
       expect(decision_service.bucketer).not_to have_received(:bucket)
@@ -63,7 +65,8 @@ describe Optimizely::DecisionService do
     end
 
     it 'should return the correct variation ID for a given user ID and key of a running experiment' do
-      expect(decision_service.get_variation(config, 'test_experiment', 'test_user')).to eq('111128')
+      variation_received, = decision_service.get_variation(config, 'test_experiment', 'test_user')
+      expect(variation_received).to eq('111128')
 
       expect(spy_logger).to have_received(:log)
         .once.with(Logger::INFO, "User 'test_user' is in variation 'control' of experiment 'test_experiment'.")
@@ -73,18 +76,21 @@ describe Optimizely::DecisionService do
 
     it 'should return nil when user ID is not bucketed' do
       allow(decision_service.bucketer).to receive(:bucket).and_return(nil)
-      expect(decision_service.get_variation(config, 'test_experiment', 'test_user')).to eq(nil)
+      variation_received, = decision_service.get_variation(config, 'test_experiment', 'test_user')
+      expect(variation_received).to eq(nil)
 
       expect(spy_logger).to have_received(:log)
         .once.with(Logger::INFO, "User 'test_user' is in no variation.")
     end
 
     it 'should return correct variation ID if user ID is in whitelisted Variations and variation is valid' do
-      expect(decision_service.get_variation(config, 'test_experiment', 'forced_user1')).to eq('111128')
+      variation_received, = decision_service.get_variation(config, 'test_experiment', 'forced_user1')
+      expect(variation_received).to eq('111128')
       expect(spy_logger).to have_received(:log)
         .once.with(Logger::INFO, "User 'forced_user1' is whitelisted into variation 'control' of experiment 'test_experiment'.")
 
-      expect(decision_service.get_variation(config, 'test_experiment', 'forced_user2')).to eq('111129')
+      variation_received, = decision_service.get_variation(config, 'test_experiment', 'forced_user2')
+      expect(variation_received).to eq('111129')
       expect(spy_logger).to have_received(:log)
         .once.with(Logger::INFO, "User 'forced_user2' is whitelisted into variation 'variation' of experiment 'test_experiment'.")
 
@@ -99,11 +105,14 @@ describe Optimizely::DecisionService do
         'browser_type' => 'firefox',
         Optimizely::Helpers::Constants::CONTROL_ATTRIBUTES['BUCKETING_ID'] => 'pid'
       }
-      expect(decision_service.get_variation(config, 'test_experiment', 'forced_user1', user_attributes)).to eq('111128')
+
+      variation_received, = decision_service.get_variation(config, 'test_experiment', 'forced_user1', user_attributes)
+      expect(variation_received).to eq('111128')
       expect(spy_logger).to have_received(:log)
         .once.with(Logger::INFO, "User 'forced_user1' is whitelisted into variation 'control' of experiment 'test_experiment'.")
 
-      expect(decision_service.get_variation(config, 'test_experiment', 'forced_user2', user_attributes)).to eq('111129')
+      variation_received, = decision_service.get_variation(config, 'test_experiment', 'forced_user2', user_attributes)
+      expect(variation_received).to eq('111129')
       expect(spy_logger).to have_received(:log)
         .once.with(Logger::INFO, "User 'forced_user2' is whitelisted into variation 'variation' of experiment 'test_experiment'.")
 
@@ -115,7 +124,8 @@ describe Optimizely::DecisionService do
 
     it 'should return the correct variation ID for a user in a whitelisted variation (even when audience conditions do not match)' do
       user_attributes = {'browser_type' => 'wrong_browser'}
-      expect(decision_service.get_variation(config, 'test_experiment_with_audience', 'forced_audience_user', user_attributes)).to eq('122229')
+      variation_received, = decision_service.get_variation(config, 'test_experiment_with_audience', 'forced_audience_user', user_attributes)
+      expect(variation_received).to eq('122229')
       expect(spy_logger).to have_received(:log)
         .once.with(
           Logger::INFO,
@@ -129,7 +139,8 @@ describe Optimizely::DecisionService do
     end
 
     it 'should return nil if the experiment key is invalid' do
-      expect(decision_service.get_variation(config, 'totally_invalid_experiment', 'test_user', {})).to eq(nil)
+      variation_received, = decision_service.get_variation(config, 'totally_invalid_experiment', 'test_user', {})
+      expect(variation_received).to eq(nil)
 
       expect(spy_logger).to have_received(:log)
         .once.with(Logger::ERROR, "Experiment key 'totally_invalid_experiment' is not in datafile.")
@@ -137,7 +148,8 @@ describe Optimizely::DecisionService do
 
     it 'should return nil if the user does not meet the audience conditions for a given experiment' do
       user_attributes = {'browser_type' => 'chrome'}
-      expect(decision_service.get_variation(config, 'test_experiment_with_audience', 'test_user', user_attributes)).to eq(nil)
+      variation_received, = decision_service.get_variation(config, 'test_experiment_with_audience', 'test_user', user_attributes)
+      expect(variation_received).to eq(nil)
       expect(spy_logger).to have_received(:log)
         .once.with(Logger::INFO, "User 'test_user' does not meet the conditions to be in experiment 'test_experiment_with_audience'.")
 
@@ -148,7 +160,8 @@ describe Optimizely::DecisionService do
     end
 
     it 'should return nil if the given experiment is not running' do
-      expect(decision_service.get_variation(config, 'test_experiment_not_started', 'test_user')).to eq(nil)
+      variation_received, = decision_service.get_variation(config, 'test_experiment_not_started', 'test_user')
+      expect(variation_received).to eq(nil)
       expect(spy_logger).to have_received(:log)
         .once.with(Logger::INFO, "Experiment 'test_experiment_not_started' is not running.")
 
@@ -161,7 +174,8 @@ describe Optimizely::DecisionService do
     end
 
     it 'should respect forced variations within mutually exclusive grouped experiments' do
-      expect(decision_service.get_variation(config, 'group1_exp2', 'forced_group_user1')).to eq('130004')
+      variation_received, = decision_service.get_variation(config, 'group1_exp2', 'forced_group_user1')
+      expect(variation_received).to eq('130004')
       expect(spy_logger).to have_received(:log)
         .once.with(Logger::INFO, "User 'forced_group_user1' is whitelisted into variation 'g1_e2_v2' of experiment 'group1_exp2'.")
 
@@ -172,7 +186,8 @@ describe Optimizely::DecisionService do
     end
 
     it 'should bucket normally if user is whitelisted into a forced variation that is not in the datafile' do
-      expect(decision_service.get_variation(config, 'test_experiment', 'forced_user_with_invalid_variation')).to eq('111128')
+      variation_received, = decision_service.get_variation(config, 'test_experiment', 'forced_user_with_invalid_variation')
+      expect(variation_received).to eq('111128')
       expect(spy_logger).to have_received(:log)
         .once.with(
           Logger::INFO,
@@ -196,7 +211,8 @@ describe Optimizely::DecisionService do
         }
         expect(spy_user_profile_service).to receive(:lookup).once.and_return(nil)
 
-        expect(decision_service.get_variation(config, 'test_experiment', 'test_user')).to eq('111128')
+        variation_received, = decision_service.get_variation(config, 'test_experiment', 'test_user')
+        expect(variation_received).to eq('111128')
 
         # bucketing should have occurred
         expect(decision_service.bucketer).to have_received(:bucket).once
@@ -221,7 +237,8 @@ describe Optimizely::DecisionService do
         }
         expect(spy_user_profile_service).to receive(:lookup).once.and_return(nil)
 
-        expect(decision_service.get_variation(config, 'test_experiment', 'test_user', user_attributes)).to eq('111129')
+        variation_received, = decision_service.get_variation(config, 'test_experiment', 'test_user', user_attributes)
+        expect(variation_received).to eq('111129')
 
         # bucketing should have occurred
         expect(decision_service.bucketer).to have_received(:bucket).once
@@ -243,7 +260,8 @@ describe Optimizely::DecisionService do
         expect(spy_user_profile_service).to receive(:lookup)
           .with('test_user').once.and_return(saved_user_profile)
 
-        expect(decision_service.get_variation(config, 'test_experiment', 'test_user')).to eq('111129')
+        variation_received, = decision_service.get_variation(config, 'test_experiment', 'test_user')
+        expect(variation_received).to eq('111129')
         expect(spy_logger).to have_received(:log).once
                                                  .with(Logger::INFO, "Returning previously activated variation ID 111129 of experiment 'test_experiment' for user 'test_user' from user profile.")
 
@@ -268,7 +286,8 @@ describe Optimizely::DecisionService do
         expect(spy_user_profile_service).to receive(:lookup)
           .once.with('test_user').and_return(saved_user_profile)
 
-        expect(decision_service.get_variation(config, 'test_experiment', 'test_user')).to eq('111128')
+        variation_received, = decision_service.get_variation(config, 'test_experiment', 'test_user')
+        expect(variation_received).to eq('111128')
 
         # bucketing should have occurred
         expect(decision_service.bucketer).to have_received(:bucket).once
@@ -301,7 +320,8 @@ describe Optimizely::DecisionService do
         expect(spy_user_profile_service).to receive(:lookup)
           .once.with('test_user').and_return(saved_user_profile)
 
-        expect(decision_service.get_variation(config, 'test_experiment', 'test_user')).to eq('111128')
+        variation_received, = decision_service.get_variation(config, 'test_experiment', 'test_user')
+        expect(variation_received).to eq('111128')
 
         # bucketing should have occurred
         expect(decision_service.bucketer).to have_received(:bucket).once
@@ -321,7 +341,8 @@ describe Optimizely::DecisionService do
       it 'should bucket normally if the user profile service throws an error during lookup' do
         expect(spy_user_profile_service).to receive(:lookup).once.with('test_user').and_throw(:LookupError)
 
-        expect(decision_service.get_variation(config, 'test_experiment', 'test_user')).to eq('111128')
+        variation_received, = decision_service.get_variation(config, 'test_experiment', 'test_user')
+        expect(variation_received).to eq('111128')
 
         expect(spy_logger).to have_received(:log).once
                                                  .with(Logger::ERROR, "Error while looking up user profile for user ID 'test_user': uncaught throw :LookupError.")
@@ -332,7 +353,8 @@ describe Optimizely::DecisionService do
       it 'should log an error if the user profile service throws an error during save' do
         expect(spy_user_profile_service).to receive(:save).once.and_throw(:SaveError)
 
-        expect(decision_service.get_variation(config, 'test_experiment', 'test_user')).to eq('111128')
+        variation_received, = decision_service.get_variation(config, 'test_experiment', 'test_user')
+        expect(variation_received).to eq('111128')
 
         expect(spy_logger).to have_received(:log).once
                                                  .with(Logger::ERROR, "Error while saving user profile for user ID 'test_user': uncaught throw :SaveError.")
@@ -343,7 +365,8 @@ describe Optimizely::DecisionService do
           allow(spy_user_profile_service).to receive(:lookup)
             .with('test_user').once.and_return(nil)
 
-          expect(decision_service.get_variation(config, 'test_experiment', 'test_user', nil, [Optimizely::Decide::OptimizelyDecideOption::IGNORE_USER_PROFILE_SERVICE])).to eq('111128')
+          variation_received, = decision_service.get_variation(config, 'test_experiment', 'test_user', nil, [Optimizely::Decide::OptimizelyDecideOption::IGNORE_USER_PROFILE_SERVICE])
+          expect(variation_received).to eq('111128')
 
           expect(decision_service.bucketer).to have_received(:bucket)
           expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?)
@@ -355,7 +378,8 @@ describe Optimizely::DecisionService do
           allow(spy_user_profile_service).to receive(:lookup)
             .with('test_user').once.and_return(nil)
 
-          expect(decision_service.get_variation(config, 'test_experiment', 'test_user')).to eq('111128')
+          variation_received, = decision_service.get_variation(config, 'test_experiment', 'test_user')
+          expect(variation_received).to eq('111128')
 
           expect(decision_service.bucketer).to have_received(:bucket)
           expect(Optimizely::Audience).to have_received(:user_meets_audience_conditions?)
@@ -398,8 +422,8 @@ describe Optimizely::DecisionService do
 
           # make sure the user is not bucketed into the feature experiment
           allow(decision_service).to receive(:get_variation)
-            .with(config, multivariate_experiment['key'], 'user_1', user_attributes, [], nil)
-            .and_return(nil)
+            .with(config, multivariate_experiment['key'], 'user_1', user_attributes, [])
+            .and_return([nil, nil])
         end
 
         it 'should return nil and log a message' do
@@ -457,11 +481,11 @@ describe Optimizely::DecisionService do
           mutex_exp = config.experiment_key_map['group1_exp1']
           mutex_exp2 = config.experiment_key_map['group1_exp2']
           allow(decision_service).to receive(:get_variation)
-            .with(config, mutex_exp['key'], user_id, user_attributes, [], nil)
-            .and_return(nil)
+            .with(config, mutex_exp['key'], user_id, user_attributes, [])
+            .and_return([nil, nil])
           allow(decision_service).to receive(:get_variation)
-            .with(config, mutex_exp2['key'], user_id, user_attributes, [], nil)
-            .and_return(nil)
+            .with(config, mutex_exp2['key'], user_id, user_attributes, [])
+            .and_return([nil, nil])
         end
 
         it 'should return nil and log a message' do

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -397,7 +397,8 @@ describe Optimizely::DecisionService do
     describe 'when the feature flag\'s experiment ids array is empty' do
       it 'should return nil and log a message' do
         feature_flag = config.feature_flag_key_map['empty_feature']
-        expect(decision_service.get_variation_for_feature_experiment(config, feature_flag, 'user_1', user_attributes)).to eq(nil)
+        variation_received, = decision_service.get_variation_for_feature_experiment(config, feature_flag, 'user_1', user_attributes)
+        expect(variation_received).to eq(nil)
 
         expect(spy_logger).to have_received(:log).once
                                                  .with(Logger::DEBUG, "The feature flag 'empty_feature' is not used in any experiments.")
@@ -409,7 +410,8 @@ describe Optimizely::DecisionService do
         feature_flag = config.feature_flag_key_map['boolean_feature'].dup
         # any string that is not an experiment id in the data file
         feature_flag['experimentIds'] = ['1333333337']
-        expect(decision_service.get_variation_for_feature_experiment(config, feature_flag, user_id, user_attributes)).to eq(nil)
+        variation_received, = decision_service.get_variation_for_feature_experiment(config, feature_flag, user_id, user_attributes)
+        expect(variation_received).to eq(nil)
         expect(spy_logger).to have_received(:log).once
                                                  .with(Logger::DEBUG, "Feature flag experiment with ID '1333333337' is not in the datafile.")
       end
@@ -428,7 +430,8 @@ describe Optimizely::DecisionService do
 
         it 'should return nil and log a message' do
           feature_flag = config.feature_flag_key_map['multi_variate_feature']
-          expect(decision_service.get_variation_for_feature_experiment(config, feature_flag, 'user_1', user_attributes, [], nil)).to eq(nil)
+          variation_received, = decision_service.get_variation_for_feature_experiment(config, feature_flag, 'user_1', user_attributes, [])
+          expect(variation_received).to eq(nil)
 
           expect(spy_logger).to have_received(:log).once
                                                    .with(Logger::INFO, "The user 'user_1' is not bucketed into any of the experiments on the feature 'multi_variate_feature'.")
@@ -449,7 +452,8 @@ describe Optimizely::DecisionService do
             config.variation_id_map['test_experiment_multivariate']['122231'],
             Optimizely::DecisionService::DECISION_SOURCES['FEATURE_TEST']
           )
-          expect(decision_service.get_variation_for_feature_experiment(config, feature_flag, 'user_1', user_attributes)).to eq(expected_decision)
+          variation_received, = decision_service.get_variation_for_feature_experiment(config, feature_flag, 'user_1', user_attributes)
+          expect(variation_received).to eq(expected_decision)
         end
       end
     end
@@ -472,7 +476,8 @@ describe Optimizely::DecisionService do
 
         it 'should return the variation the user is bucketed into' do
           feature_flag = config.feature_flag_key_map['mutex_group_feature']
-          expect(decision_service.get_variation_for_feature_experiment(config, feature_flag, user_id, user_attributes)).to eq(expected_decision)
+          variation_received, = decision_service.get_variation_for_feature_experiment(config, feature_flag, user_id, user_attributes)
+          expect(variation_received).to eq(expected_decision)
         end
       end
 
@@ -490,7 +495,8 @@ describe Optimizely::DecisionService do
 
         it 'should return nil and log a message' do
           feature_flag = config.feature_flag_key_map['mutex_group_feature']
-          expect(decision_service.get_variation_for_feature_experiment(config, feature_flag, user_id, user_attributes)).to eq(nil)
+          variation_received, = decision_service.get_variation_for_feature_experiment(config, feature_flag, user_id, user_attributes)
+          expect(variation_received).to eq(nil)
 
           expect(spy_logger).to have_received(:log).once
                                                    .with(Logger::INFO, "The user 'user_1' is not bucketed into any of the experiments on the feature 'mutex_group_feature'.")

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -72,7 +72,6 @@ describe Optimizely::DecisionService do
 
       expect(reasons).to eq([
                               "User 'test_user' is not in the forced variation map.",
-                              "Evaluating audiences for experiment 'test_experiment': [].",
                               "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                               "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                               "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
@@ -90,7 +89,6 @@ describe Optimizely::DecisionService do
       expect(variation_received).to eq(nil)
       expect(reasons).to eq([
                               "User 'test_user' is not in the forced variation map.",
-                              "Evaluating audiences for experiment 'test_experiment': [].",
                               "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                               "User 'test_user' is in no variation."
                             ])
@@ -189,7 +187,6 @@ describe Optimizely::DecisionService do
       expect(variation_received).to eq(nil)
       expect(reasons).to eq([
                               "User 'test_user' is not in the forced variation map.",
-                              "Evaluating audiences for experiment 'test_experiment_with_audience': [\"11154\"].",
                               "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
                               "Audience '11154' evaluated to FALSE.",
                               "Audiences for experiment 'test_experiment_with_audience' collectively evaluated to FALSE.",
@@ -241,7 +238,6 @@ describe Optimizely::DecisionService do
       expect(reasons).to eq([
                               "User 'forced_user_with_invalid_variation' is not in the forced variation map.",
                               "User 'forced_user_with_invalid_variation' is whitelisted into variation 'invalid_variation', which is not in the datafile.",
-                              "Evaluating audiences for experiment 'test_experiment': [].",
                               "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                               "Assigned bucket 877 to user 'forced_user_with_invalid_variation' with bucketing ID: 'forced_user_with_invalid_variation'.",
                               "User 'forced_user_with_invalid_variation' is in variation 'control' of experiment 'test_experiment'."
@@ -273,7 +269,6 @@ describe Optimizely::DecisionService do
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
                                 "User 'test_user' is not in the forced variation map.",
-                                "Evaluating audiences for experiment 'test_experiment': [].",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
@@ -306,7 +301,6 @@ describe Optimizely::DecisionService do
         expect(variation_received).to eq('111129')
         expect(reasons).to eq([
                                 "User 'test_user' is not in the forced variation map.",
-                                "Evaluating audiences for experiment 'test_experiment': [].",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 8933 to user 'test_user' with bucketing ID: 'pid'.",
                                 "User 'test_user' is in variation 'variation' of experiment 'test_experiment'."
@@ -366,7 +360,6 @@ describe Optimizely::DecisionService do
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
                                 "User 'test_user' is not in the forced variation map.",
-                                "Evaluating audiences for experiment 'test_experiment': [].",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
@@ -408,7 +401,6 @@ describe Optimizely::DecisionService do
         expect(reasons).to eq([
                                 "User 'test_user' is not in the forced variation map.",
                                 "User '' was previously bucketed into variation ID '111111' for experiment '111127', but no matching variation was found. Re-bucketing user.",
-                                "Evaluating audiences for experiment 'test_experiment': [].",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
@@ -437,7 +429,6 @@ describe Optimizely::DecisionService do
         expect(reasons).to eq([
                                 "User 'test_user' is not in the forced variation map.",
                                 "Error while looking up user profile for user ID 'test_user': uncaught throw :LookupError.",
-                                "Evaluating audiences for experiment 'test_experiment': [].",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
@@ -456,7 +447,6 @@ describe Optimizely::DecisionService do
         expect(variation_received).to eq('111128')
         expect(reasons).to eq([
                                 "User 'test_user' is not in the forced variation map.",
-                                "Evaluating audiences for experiment 'test_experiment': [].",
                                 "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                 "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                 "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
@@ -475,7 +465,6 @@ describe Optimizely::DecisionService do
           expect(variation_received).to eq('111128')
           expect(reasons).to eq([
                                   "User 'test_user' is not in the forced variation map.",
-                                  "Evaluating audiences for experiment 'test_experiment': [].",
                                   "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                   "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                   "User 'test_user' is in variation 'control' of experiment 'test_experiment'."
@@ -495,7 +484,6 @@ describe Optimizely::DecisionService do
           expect(variation_received).to eq('111128')
           expect(reasons).to eq([
                                   "User 'test_user' is not in the forced variation map.",
-                                  "Evaluating audiences for experiment 'test_experiment': [].",
                                   "Audiences for experiment 'test_experiment' collectively evaluated to TRUE.",
                                   "Assigned bucket 4577 to user 'test_user' with bucketing ID: 'test_user'.",
                                   "User 'test_user' is in variation 'control' of experiment 'test_experiment'."

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -695,7 +695,8 @@ describe Optimizely::DecisionService do
         'browser_type' => 'firefox',
         Optimizely::Helpers::Constants::CONTROL_ATTRIBUTES['BUCKETING_ID'] => 5
       }
-      expect(decision_service.send(:get_bucketing_id, 'test_user', user_attributes)).to eq('test_user')
+      bucketing_id, = decision_service.send(:get_bucketing_id, 'test_user', user_attributes)
+      expect(bucketing_id).to eq('test_user')
       expect(spy_logger).to have_received(:log).once.with(Logger::WARN, 'Bucketing ID attribute is not a string. Defaulted to user ID.')
     end
 
@@ -704,7 +705,8 @@ describe Optimizely::DecisionService do
         'browser_type' => 'firefox',
         Optimizely::Helpers::Constants::CONTROL_ATTRIBUTES['BUCKETING_ID'] => nil
       }
-      expect(decision_service.send(:get_bucketing_id, 'test_user', user_attributes)).to eq('test_user')
+      bucketing_id, = decision_service.send(:get_bucketing_id, 'test_user', user_attributes)
+      expect(bucketing_id).to eq('test_user')
       expect(spy_logger).not_to have_received(:log)
     end
 
@@ -713,7 +715,8 @@ describe Optimizely::DecisionService do
         'browser_type' => 'firefox',
         Optimizely::Helpers::Constants::CONTROL_ATTRIBUTES['BUCKETING_ID'] => 'i_am_bucketing_id'
       }
-      expect(decision_service.send(:get_bucketing_id, 'test_user', user_attributes)).to eq('i_am_bucketing_id')
+      bucketing_id, = decision_service.send(:get_bucketing_id, 'test_user', user_attributes)
+      expect(bucketing_id).to eq('i_am_bucketing_id')
       expect(spy_logger).not_to have_received(:log)
     end
 
@@ -722,7 +725,8 @@ describe Optimizely::DecisionService do
         'browser_type' => 'firefox',
         Optimizely::Helpers::Constants::CONTROL_ATTRIBUTES['BUCKETING_ID'] => ''
       }
-      expect(decision_service.send(:get_bucketing_id, 'test_user', user_attributes)).to eq('')
+      bucketing_id, = decision_service.send(:get_bucketing_id, 'test_user', user_attributes)
+      expect(bucketing_id).to eq('')
       expect(spy_logger).not_to have_received(:log)
     end
   end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -3903,7 +3903,6 @@ describe 'Optimizely' do
               variation_key: nil,
               rule_key: nil,
               reasons: [
-                "User 'user1' is not in the forced variation map.",
                 "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
                 "Audience '11154' evaluated to UNKNOWN.",
                 "Audiences for experiment 'test_experiment_multivariate' collectively evaluated to FALSE.",
@@ -3920,7 +3919,6 @@ describe 'Optimizely' do
             flag_key: 'multi_variate_feature',
             enabled: false,
             reasons: [
-              "User 'user1' is not in the forced variation map.",
               "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
               "Audience '11154' evaluated to UNKNOWN.",
               "Audiences for experiment 'test_experiment_multivariate' collectively evaluated to FALSE.",
@@ -4254,7 +4252,6 @@ describe 'Optimizely' do
             variation_key: nil,
             rule_key: nil,
             reasons: [
-              "User 'user1' is not in the forced variation map.",
               "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
               "Audience '11154' evaluated to UNKNOWN.",
               "Audiences for experiment 'test_experiment_multivariate' collectively evaluated to FALSE.",
@@ -4271,7 +4268,6 @@ describe 'Optimizely' do
           flag_key: 'multi_variate_feature',
           enabled: false,
           reasons: [
-            "User 'user1' is not in the forced variation map.",
             "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
             "Audience '11154' evaluated to UNKNOWN.",
             "Audiences for experiment 'test_experiment_multivariate' collectively evaluated to FALSE.",

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -214,7 +214,7 @@ describe 'Optimizely' do
       params = @expected_activate_params
 
       variation_to_return = project_config.get_variation_from_id('test_experiment', '111128')
-      allow(project_instance.decision_service.bucketer).to receive(:bucket).and_return(variation_to_return)
+      allow(project_instance.decision_service.bucketer).to receive(:bucket).and_return([variation_to_return, nil])
       allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
       allow(project_config).to receive(:get_audience_ids_for_experiment)
         .with('test_experiment')

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -3904,7 +3904,6 @@ describe 'Optimizely' do
               rule_key: nil,
               reasons: [
                 "User 'user1' is not in the forced variation map.",
-                "Evaluating audiences for experiment 'test_experiment_multivariate': [\"11154\"].",
                 "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
                 "Audience '11154' evaluated to UNKNOWN.",
                 "Audiences for experiment 'test_experiment_multivariate' collectively evaluated to FALSE.",
@@ -3922,7 +3921,6 @@ describe 'Optimizely' do
             enabled: false,
             reasons: [
               "User 'user1' is not in the forced variation map.",
-              "Evaluating audiences for experiment 'test_experiment_multivariate': [\"11154\"].",
               "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
               "Audience '11154' evaluated to UNKNOWN.",
               "Audiences for experiment 'test_experiment_multivariate' collectively evaluated to FALSE.",
@@ -4257,7 +4255,6 @@ describe 'Optimizely' do
             rule_key: nil,
             reasons: [
               "User 'user1' is not in the forced variation map.",
-              "Evaluating audiences for experiment 'test_experiment_multivariate': [\"11154\"].",
               "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
               "Audience '11154' evaluated to UNKNOWN.",
               "Audiences for experiment 'test_experiment_multivariate' collectively evaluated to FALSE.",
@@ -4275,7 +4272,6 @@ describe 'Optimizely' do
           enabled: false,
           reasons: [
             "User 'user1' is not in the forced variation map.",
-            "Evaluating audiences for experiment 'test_experiment_multivariate': [\"11154\"].",
             "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
             "Audience '11154' evaluated to UNKNOWN.",
             "Audiences for experiment 'test_experiment_multivariate' collectively evaluated to FALSE.",

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -3974,11 +3974,11 @@ describe 'Optimizely' do
         user_context = project_instance.create_user_context('user1')
 
         expect(project_instance.decision_service).to receive(:get_variation_for_feature)
-          .with(anything, anything, anything, anything, [], []).once
+          .with(anything, anything, anything, anything, []).once
         project_instance.decide(user_context, 'multi_variate_feature')
 
         expect(project_instance.decision_service).to receive(:get_variation_for_feature)
-          .with(anything, anything, anything, anything, [Optimizely::Decide::OptimizelyDecideOption::DISABLE_DECISION_EVENT], []).once
+          .with(anything, anything, anything, anything, [Optimizely::Decide::OptimizelyDecideOption::DISABLE_DECISION_EVENT]).once
         project_instance.decide(user_context, 'multi_variate_feature', [Optimizely::Decide::OptimizelyDecideOption::DISABLE_DECISION_EVENT])
 
         expect(project_instance.decision_service).to receive(:get_variation_for_feature)
@@ -3989,7 +3989,7 @@ describe 'Optimizely' do
                   Optimizely::Decide::OptimizelyDecideOption::IGNORE_USER_PROFILE_SERVICE,
                   Optimizely::Decide::OptimizelyDecideOption::INCLUDE_REASONS,
                   Optimizely::Decide::OptimizelyDecideOption::EXCLUDE_VARIABLES
-                ], []).once
+                ]).once
         project_instance
           .decide(user_context, 'multi_variate_feature', [
                     Optimizely::Decide::OptimizelyDecideOption::DISABLE_DECISION_EVENT,

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -3904,6 +3904,10 @@ describe 'Optimizely' do
               rule_key: nil,
               reasons: [
                 "User 'user1' is not in the forced variation map.",
+                "Evaluating audiences for experiment 'test_experiment_multivariate': [\"11154\"].",
+                "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
+                "Audience '11154' evaluated to UNKNOWN.",
+                "Audiences for experiment 'test_experiment_multivariate' collectively evaluated to FALSE.",
                 "User 'user1' does not meet the conditions to be in experiment 'test_experiment_multivariate'.",
                 "The user 'user1' is not bucketed into any of the experiments on the feature 'multi_variate_feature'.",
                 "Feature flag 'multi_variate_feature' is not used in a rollout."
@@ -3918,6 +3922,10 @@ describe 'Optimizely' do
             enabled: false,
             reasons: [
               "User 'user1' is not in the forced variation map.",
+              "Evaluating audiences for experiment 'test_experiment_multivariate': [\"11154\"].",
+              "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
+              "Audience '11154' evaluated to UNKNOWN.",
+              "Audiences for experiment 'test_experiment_multivariate' collectively evaluated to FALSE.",
               "User 'user1' does not meet the conditions to be in experiment 'test_experiment_multivariate'.",
               "The user 'user1' is not bucketed into any of the experiments on the feature 'multi_variate_feature'.",
               "Feature flag 'multi_variate_feature' is not used in a rollout."
@@ -4249,6 +4257,10 @@ describe 'Optimizely' do
             rule_key: nil,
             reasons: [
               "User 'user1' is not in the forced variation map.",
+              "Evaluating audiences for experiment 'test_experiment_multivariate': [\"11154\"].",
+              "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
+              "Audience '11154' evaluated to UNKNOWN.",
+              "Audiences for experiment 'test_experiment_multivariate' collectively evaluated to FALSE.",
               "User 'user1' does not meet the conditions to be in experiment 'test_experiment_multivariate'.",
               "The user 'user1' is not bucketed into any of the experiments on the feature 'multi_variate_feature'.",
               "Feature flag 'multi_variate_feature' is not used in a rollout."
@@ -4263,6 +4275,10 @@ describe 'Optimizely' do
           enabled: false,
           reasons: [
             "User 'user1' is not in the forced variation map.",
+            "Evaluating audiences for experiment 'test_experiment_multivariate': [\"11154\"].",
+            "Starting to evaluate audience '11154' with conditions: [\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"firefox\"}]]].",
+            "Audience '11154' evaluated to UNKNOWN.",
+            "Audiences for experiment 'test_experiment_multivariate' collectively evaluated to FALSE.",
             "User 'user1' does not meet the conditions to be in experiment 'test_experiment_multivariate'.",
             "The user 'user1' is not bucketed into any of the experiments on the feature 'multi_variate_feature'.",
             "Feature flag 'multi_variate_feature' is not used in a rollout."


### PR DESCRIPTION
## Summary
Reasons were previously being collected by sending a reasons object down the stack to all the related functions which would mutate it by pushing their own reasons. This is now changed. Every related function now returns the reasons array along with the actual value.

## Test plan
- Manually tested thoroughly.
- Fixed all the affected unit test.
- FSC passing