### PR TITLE
refact(forced-decision): Support for decision context added.

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -198,8 +198,8 @@ module Optimizely
       decision_event_dispatched = false
       experiment = nil
       decision_source = Optimizely::DecisionService::DECISION_SOURCES['ROLLOUT']
-
-      variation, reasons_received = user_context.find_validated_forced_decision(key, nil)
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(key, nil)
+      variation, reasons_received = user_context.find_validated_forced_decision(context)
       reasons.push(*reasons_received)
 
       if variation

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -263,7 +263,8 @@ module Optimizely
       # Returns variation_id and reasons
       reasons = []
 
-      variation, forced_reasons = user.find_validated_forced_decision(flag_key, rule['key'])
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(flag_key, rule['key'])
+      variation, forced_reasons = user.find_validated_forced_decision(context)
       reasons.push(*forced_reasons)
 
       return [variation['id'], reasons] if variation
@@ -287,7 +288,8 @@ module Optimizely
       reasons = []
       skip_to_everyone_else = false
       rule = rules[rule_index]
-      variation, forced_reasons = user.find_validated_forced_decision(flag_key, rule['key'])
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(flag_key, rule['key'])
+      variation, forced_reasons = user.find_validated_forced_decision(context)
       reasons.push(*forced_reasons)
 
       return [variation, skip_to_everyone_else, reasons] if variation

--- a/lib/optimizely/optimizely_user_context.rb
+++ b/lib/optimizely/optimizely_user_context.rb
@@ -28,7 +28,7 @@ module Optimizely
     attr_reader :OptimizelyForcedDecision
 
     OptimizelyDecisionContext = Struct.new(:flag_key, :rule_key)
-    OptimizelyForcedDecision = Struct.new(:variation)
+    OptimizelyForcedDecision = Struct.new(:variation_key)
     def initialize(optimizely_client, user_id, user_attributes)
       @attr_mutex = Mutex.new
       @forced_decision_mutex = Mutex.new
@@ -165,7 +165,7 @@ module Optimizely
       decision = find_forced_decision(context)
       flag_key = context[:flag_key]
       rule_key = context[:rule_key]
-      variation_key = decision ? decision[:variation] : decision
+      variation_key = decision ? decision[:variation_key] : decision
       reasons = []
       target = rule_key ? "flag (#{flag_key}), rule (#{rule_key})" : "flag (#{flag_key})"
       if variation_key

--- a/lib/optimizely/optimizely_user_context.rb
+++ b/lib/optimizely/optimizely_user_context.rb
@@ -104,7 +104,7 @@ module Optimizely
     def set_forced_decision(context, decision)
       flag_key = context[:flag_key]
       return false if @optimizely_client&.get_optimizely_config.nil?
-      return false if flag_key.empty? || flag_key.nil?
+      return false if flag_key.nil?
 
       @forced_decision_mutex.synchronize { @forced_decisions[context] = decision }
 

--- a/lib/optimizely/optimizely_user_context.rb
+++ b/lib/optimizely/optimizely_user_context.rb
@@ -96,9 +96,8 @@ module Optimizely
 
     # Sets the forced decision (variation key) for a given flag and an optional rule.
     #
-    # @param flag_key - A flag key.
-    # @param rule_key - An experiment or delivery rule key (optional).
-    # @param variation_key - A variation key.
+    # @param context - An OptimizelyDecisionContext object containg flag key and rule key.
+    # @param decision - An OptimizelyForcedDecision object containing variation key
     #
     # @return - true if the forced decision has been set successfully.
 
@@ -122,8 +121,7 @@ module Optimizely
 
     # Returns the forced decision for a given flag and an optional rule.
     #
-    # @param flag_key - A flag key.
-    # @param rule_key - An experiment or delivery rule key (optional).
+    # @param context - An OptimizelyDecisionContext object containg flag key and rule key.
     #
     # @return - A variation key or nil if forced decisions are not set for the parameters.
 
@@ -135,8 +133,7 @@ module Optimizely
 
     # Removes the forced decision for a given flag and an optional rule.
     #
-    # @param flag_key - A flag key.
-    # @param rule_key - An experiment or delivery rule key (optional).
+    # @param context - An OptimizelyDecisionContext object containg flag key and rule key.
     #
     # @return - true if the forced decision has been removed successfully.
 

--- a/spec/optimizely_user_context_spec.rb
+++ b/spec/optimizely_user_context_spec.rb
@@ -90,11 +90,14 @@ describe 'Optimizely' do
       original_attributes = {}
       invalid_project_instance = Optimizely::Project.new('Invalid datafile', nil, spy_logger, error_handler)
       user_context_obj = Optimizely::OptimizelyUserContext.new(invalid_project_instance, user_id, original_attributes)
-      status = user_context_obj.set_forced_decision('feature_1', nil, '3324490562')
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new('feature_1', nil)
+      decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('3324490562')
+
+      status = user_context_obj.set_forced_decision(context, decision)
       expect(status).to be false
-      status = user_context_obj.get_forced_decision('feature_1')
+      status = user_context_obj.get_forced_decision(context)
       expect(status).to be_nil
-      status = user_context_obj.remove_forced_decision('feature_1')
+      status = user_context_obj.remove_forced_decision(context)
       expect(status).to be false
       status = user_context_obj.remove_all_forced_decision
       expect(status).to be false
@@ -104,11 +107,13 @@ describe 'Optimizely' do
       user_id = 'test_user'
       original_attributes = {}
       user_context_obj = Optimizely::OptimizelyUserContext.new(project_instance, user_id, original_attributes)
-      status = user_context_obj.set_forced_decision('feature_1', nil, '3324490562')
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new('feature_1', nil)
+      decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('3324490562')
+      status = user_context_obj.set_forced_decision(context, decision)
       expect(status).to be true
-      status = user_context_obj.get_forced_decision('feature_1')
-      expect(status).to eq('3324490562')
-      status = user_context_obj.remove_forced_decision('feature_1')
+      status = user_context_obj.get_forced_decision(context)
+      expect(status).to eq(decision)
+      status = user_context_obj.remove_forced_decision(context)
       expect(status).to be true
       status = user_context_obj.remove_all_forced_decision
       expect(status).to be true
@@ -189,7 +194,9 @@ describe 'Optimizely' do
           decision_event_dispatched: true
         )
       user_context_obj = forced_decision_project_instance.create_user_context(user_id)
-      user_context_obj.set_forced_decision(feature_key, nil, '3324490562')
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, nil)
+      forced_decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('3324490562')
+      user_context_obj.set_forced_decision(context, forced_decision)
       decision = user_context_obj.decide(feature_key)
       expect(forced_decision_project_instance.event_dispatcher).to have_received(:dispatch_event).with(Optimizely::Event.new(:post, impression_log_url, expected_params, post_headers))
       expect(decision.variation_key).to eq('3324490562')
@@ -200,7 +207,7 @@ describe 'Optimizely' do
       expect(decision.user_context.user_attributes.length).to eq(0)
       expect(decision.reasons).to eq([])
       expect(decision.user_context.forced_decisions.length).to eq(1)
-      expect(decision.user_context.forced_decisions).to eq(Optimizely::OptimizelyUserContext::ForcedDecision.new(feature_key, nil) => '3324490562')
+      expect(decision.user_context.forced_decisions).to eq(context => forced_decision)
     end
 
     it 'should set experiment rule in forced decision using set forced decision' do
@@ -279,7 +286,9 @@ describe 'Optimizely' do
           decision_event_dispatched: true
         )
       user_context_obj = Optimizely::OptimizelyUserContext.new(forced_decision_project_instance, user_id, original_attributes)
-      user_context_obj.set_forced_decision(feature_key, 'exp_with_audience', 'b')
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, 'exp_with_audience')
+      forced_decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('b')
+      user_context_obj.set_forced_decision(context, forced_decision)
       decision = user_context_obj.decide(feature_key, [Optimizely::Decide::OptimizelyDecideOption::INCLUDE_REASONS])
       expect(forced_decision_project_instance.event_dispatcher).to have_received(:dispatch_event).with(Optimizely::Event.new(:post, impression_log_url, expected_params, post_headers))
       expect(decision.variation_key).to eq('b')
@@ -289,7 +298,7 @@ describe 'Optimizely' do
       expect(decision.user_context.user_id).to eq(user_id)
       expect(decision.user_context.user_attributes.length).to eq(0)
       expect(decision.user_context.forced_decisions.length).to eq(1)
-      expect(decision.user_context.forced_decisions).to eq(Optimizely::OptimizelyUserContext::ForcedDecision.new(feature_key, 'exp_with_audience') => 'b')
+      expect(decision.user_context.forced_decisions).to eq(context => forced_decision)
       expect(decision.reasons).to eq(['Variation (b) is mapped to flag (feature_1), rule (exp_with_audience) and user (tester) in the forced decision map.'])
     end
 
@@ -367,12 +376,16 @@ describe 'Optimizely' do
           decision_event_dispatched: true
         )
       user_context_obj = forced_decision_project_instance.create_user_context(user_id)
+      context_with_flag = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, nil)
+      decision_for_flag = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('3324490562')
+      context_with_rule = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, 'exp_with_audience')
+      decision_for_rule = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('b')
       # set forced decision with flag
-      user_context_obj.set_forced_decision(feature_key, nil, '3324490562')
+      user_context_obj.set_forced_decision(context_with_flag, decision_for_flag)
       # set forced decision with flag and rule
-      user_context_obj.set_forced_decision(feature_key, 'exp_with_audience', 'b')
+      user_context_obj.set_forced_decision(context_with_rule, decision_for_rule)
       # remove rule forced decision with flag
-      user_context_obj.remove_forced_decision(feature_key, 'exp_with_audience')
+      user_context_obj.remove_forced_decision(context_with_rule)
       # decision should be based on flag forced decision
       decision = user_context_obj.decide(feature_key)
       expect(forced_decision_project_instance.event_dispatcher).to have_received(:dispatch_event).with(Optimizely::Event.new(:post, impression_log_url, expected_params, post_headers))
@@ -384,7 +397,7 @@ describe 'Optimizely' do
       expect(decision.user_context.user_attributes.length).to eq(0)
       expect(decision.reasons).to eq([])
       expect(decision.user_context.forced_decisions.length).to eq(1)
-      expect(decision.user_context.forced_decisions).to eq(Optimizely::OptimizelyUserContext::ForcedDecision.new(feature_key, nil) => '3324490562')
+      expect(decision.user_context.forced_decisions).to eq(context_with_flag => decision_for_flag)
     end
 
     it 'should set delivery rule in forced decision using set forced decision' do
@@ -393,7 +406,9 @@ describe 'Optimizely' do
       original_attributes = {}
       stub_request(:post, impression_log_url)
       user_context_obj = Optimizely::OptimizelyUserContext.new(forced_decision_project_instance, user_id, original_attributes)
-      user_context_obj.set_forced_decision(feature_key, '3332020515', '3324490633')
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, '3332020515')
+      forced_decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('3324490633')
+      user_context_obj.set_forced_decision(context, forced_decision)
       decision = user_context_obj.decide(feature_key)
       expect(decision.variation_key).to eq('3324490633')
       expect(decision.rule_key).to eq('3332020515')
@@ -403,7 +418,7 @@ describe 'Optimizely' do
       expect(decision.user_context.user_attributes.length).to eq(0)
       expect(decision.reasons).to eq([])
       expect(decision.user_context.forced_decisions.length).to eq(1)
-      expect(decision.user_context.forced_decisions).to eq(Optimizely::OptimizelyUserContext::ForcedDecision.new(feature_key, '3332020515') => '3324490633')
+      expect(decision.user_context.forced_decisions).to eq(context => forced_decision)
 
       decision = user_context_obj.decide(feature_key, [Optimizely::Decide::OptimizelyDecideOption::INCLUDE_REASONS])
       expect(decision.reasons).to eq([
@@ -424,7 +439,9 @@ describe 'Optimizely' do
 
       # flag-to-decision
       user_context_obj = Optimizely::OptimizelyUserContext.new(forced_decision_project_instance, user_id, original_attributes)
-      user_context_obj.set_forced_decision(feature_key, nil, 'invalid')
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, nil)
+      decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('invalid')
+      user_context_obj.set_forced_decision(context, decision)
       decision = user_context_obj.decide(feature_key, [Optimizely::Decide::OptimizelyDecideOption::INCLUDE_REASONS])
       expect(decision.variation_key).to eq('18257766532')
       expect(decision.rule_key).to eq('18322080788')
@@ -432,7 +449,9 @@ describe 'Optimizely' do
 
       # experiment-rule-to-decision
       user_context_obj = Optimizely::OptimizelyUserContext.new(forced_decision_project_instance, user_id, original_attributes)
-      user_context_obj.set_forced_decision(feature_key, 'exp_with_audience', 'invalid')
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, 'exp_with_audience')
+      decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('invalid')
+      user_context_obj.set_forced_decision(context, decision)
       decision = user_context_obj.decide(feature_key, [Optimizely::Decide::OptimizelyDecideOption::INCLUDE_REASONS])
       expect(decision.variation_key).to eq('18257766532')
       expect(decision.rule_key).to eq('18322080788')
@@ -440,7 +459,9 @@ describe 'Optimizely' do
 
       # delivery-rule-to-decision
       user_context_obj = Optimizely::OptimizelyUserContext.new(forced_decision_project_instance, user_id, original_attributes)
-      user_context_obj.set_forced_decision(feature_key, '3332020515', 'invalid')
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, '3332020515')
+      decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('invalid')
+      user_context_obj.set_forced_decision(context, decision)
       decision = user_context_obj.decide(feature_key, [Optimizely::Decide::OptimizelyDecideOption::INCLUDE_REASONS])
       expect(decision.variation_key).to eq('18257766532')
       expect(decision.rule_key).to eq('18322080788')
@@ -453,8 +474,12 @@ describe 'Optimizely' do
       original_attributes = {}
       stub_request(:post, impression_log_url)
       user_context_obj = Optimizely::OptimizelyUserContext.new(forced_decision_project_instance, user_id, original_attributes)
-      user_context_obj.set_forced_decision(feature_key, nil, '3324490562')
-      user_context_obj.set_forced_decision(feature_key, 'exp_with_audience', 'b')
+      context_with_flag = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, nil)
+      decision_for_flag = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('3324490562')
+      context_with_rule = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, 'exp_with_audience')
+      decision_for_rule = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('b')
+      user_context_obj.set_forced_decision(context_with_flag, decision_for_flag)
+      user_context_obj.set_forced_decision(context_with_rule, decision_for_rule)
       decision = user_context_obj.decide(feature_key)
       expect(decision.variation_key).to eq('3324490562')
       expect(decision.rule_key).to be_nil
@@ -466,19 +491,29 @@ describe 'Optimizely' do
       original_attributes = {}
       stub_request(:post, impression_log_url)
       user_context_obj = Optimizely::OptimizelyUserContext.new(forced_decision_project_instance, user_id, original_attributes)
-      user_context_obj.set_forced_decision(feature_key, nil, 'fv1')
-      expect(user_context_obj.get_forced_decision(feature_key)).to eq('fv1')
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, nil)
+      decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('fv1')
+      user_context_obj.set_forced_decision(context, decision)
+      expect(user_context_obj.get_forced_decision(context)).to eq(decision)
 
-      user_context_obj.set_forced_decision(feature_key, nil, 'fv2')
-      expect(user_context_obj.get_forced_decision(feature_key)).to eq('fv2')
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, nil)
+      decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('fv2')
+      user_context_obj.set_forced_decision(context, decision)
+      expect(user_context_obj.get_forced_decision(context)).to eq(decision)
 
-      user_context_obj.set_forced_decision(feature_key, 'r', 'ev1')
-      expect(user_context_obj.get_forced_decision(feature_key, 'r')).to eq('ev1')
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, 'r')
+      decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('ev1')
+      user_context_obj.set_forced_decision(context, decision)
+      expect(user_context_obj.get_forced_decision(context)).to eq(decision)
 
-      user_context_obj.set_forced_decision(feature_key, 'r', 'ev2')
-      expect(user_context_obj.get_forced_decision(feature_key, 'r')).to eq('ev2')
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, 'r')
+      decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('ev2')
+      user_context_obj.set_forced_decision(context, decision)
+      expect(user_context_obj.get_forced_decision(context)).to eq(decision)
 
-      expect(user_context_obj.get_forced_decision(feature_key)).to eq('fv2')
+      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, nil)
+      decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('fv2')
+      expect(user_context_obj.get_forced_decision(context)).to eq(decision)
     end
 
     it 'should remove forced decision' do
@@ -487,23 +522,28 @@ describe 'Optimizely' do
       original_attributes = {}
       stub_request(:post, impression_log_url)
       user_context_obj = Optimizely::OptimizelyUserContext.new(forced_decision_project_instance, user_id, original_attributes)
-      user_context_obj.set_forced_decision(feature_key, nil, 'fv1')
-      user_context_obj.set_forced_decision(feature_key, 'r', 'ev1')
+      context_with_flag = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, nil)
+      decision_for_flag = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('fv1')
+      user_context_obj.set_forced_decision(context_with_flag, decision_for_flag)
 
-      expect(user_context_obj.get_forced_decision(feature_key)).to eq('fv1')
-      expect(user_context_obj.get_forced_decision(feature_key, 'r')).to eq('ev1')
+      context_with_rule = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, 'r')
+      decision_for_rule = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('ev1')
+      user_context_obj.set_forced_decision(context_with_rule, decision_for_rule)
 
-      status = user_context_obj.remove_forced_decision(feature_key)
+      expect(user_context_obj.get_forced_decision(context_with_flag)).to eq(decision_for_flag)
+      expect(user_context_obj.get_forced_decision(context_with_rule)).to eq(decision_for_rule)
+
+      status = user_context_obj.remove_forced_decision(context_with_flag)
       expect(status).to be true
-      expect(user_context_obj.get_forced_decision(feature_key)).to be_nil
-      expect(user_context_obj.get_forced_decision(feature_key, 'r')).to eq('ev1')
+      expect(user_context_obj.get_forced_decision(context_with_flag)).to be_nil
+      expect(user_context_obj.get_forced_decision(context_with_rule)).to eq(decision_for_rule)
 
-      status = user_context_obj.remove_forced_decision(feature_key, 'r')
+      status = user_context_obj.remove_forced_decision(context_with_rule)
       expect(status).to be true
-      expect(user_context_obj.get_forced_decision(feature_key)).to be_nil
-      expect(user_context_obj.get_forced_decision(feature_key, 'r')).to be_nil
+      expect(user_context_obj.get_forced_decision(context_with_flag)).to be_nil
+      expect(user_context_obj.get_forced_decision(context_with_rule)).to be_nil
 
-      status = user_context_obj.remove_forced_decision(feature_key)
+      status = user_context_obj.remove_forced_decision(context_with_flag)
       expect(status).to be false
     end
 
@@ -513,17 +553,23 @@ describe 'Optimizely' do
       original_attributes = {}
       stub_request(:post, impression_log_url)
       user_context_obj = Optimizely::OptimizelyUserContext.new(forced_decision_project_instance, user_id, original_attributes)
-      user_context_obj.set_forced_decision(feature_key, nil, 'fv1')
-      user_context_obj.set_forced_decision(feature_key, 'r', 'ev1')
+      context_with_flag = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, nil)
+      decision_for_flag = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('fv1')
 
-      expect(user_context_obj.get_forced_decision(feature_key)).to eq('fv1')
-      expect(user_context_obj.get_forced_decision(feature_key, 'r')).to eq('ev1')
+      context_with_rule = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, 'r')
+      decision_for_rule = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('ev1')
+
+      user_context_obj.set_forced_decision(context_with_flag, decision_for_flag)
+      user_context_obj.set_forced_decision(context_with_rule, decision_for_rule)
+
+      expect(user_context_obj.get_forced_decision(context_with_flag)).to eq(decision_for_flag)
+      expect(user_context_obj.get_forced_decision(context_with_rule)).to eq(decision_for_rule)
 
       user_context_obj.remove_all_forced_decision
-      expect(user_context_obj.get_forced_decision(feature_key)).to be_nil
-      expect(user_context_obj.get_forced_decision(feature_key, 'r')).to be_nil
+      expect(user_context_obj.get_forced_decision(context_with_flag)).to be_nil
+      expect(user_context_obj.get_forced_decision(context_with_rule)).to be_nil
 
-      status = user_context_obj.remove_forced_decision(feature_key)
+      status = user_context_obj.remove_forced_decision(context_with_flag)
       expect(status).to be false
     end
 
@@ -538,25 +584,38 @@ describe 'Optimizely' do
       expect(user_clone_1.user_attributes).to eq(original_attributes)
       expect(user_clone_1.forced_decisions).to be_empty
 
+      context_with_flag = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new('a', nil)
+      decision_for_flag = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('b')
+
+      context_with_rule = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new('a', 'c')
+      decision_for_rule = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('d')
+
+      context_with_empty_rule = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new('a', '')
+      decision_for_empty_rule = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('e')
+
+      unassigned_context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new('x', nil)
+
       # with forced decisions
-      user_context_obj.set_forced_decision('a', nil, 'b')
-      user_context_obj.set_forced_decision('a', 'c', 'd')
-      user_context_obj.set_forced_decision('a', '', 'e')
+      user_context_obj.set_forced_decision(context_with_flag, decision_for_flag)
+      user_context_obj.set_forced_decision(context_with_rule, decision_for_rule)
+      user_context_obj.set_forced_decision(context_with_empty_rule, decision_for_empty_rule)
 
       user_clone_2 = user_context_obj.clone
       expect(user_clone_2.user_id).to eq(user_id)
       expect(user_clone_2.user_attributes).to eq(original_attributes)
       expect(user_clone_2.forced_decisions).not_to be_nil
 
-      expect(user_clone_2.get_forced_decision('a')).to eq('b')
-      expect(user_clone_2.get_forced_decision('a', 'c')).to eq('d')
-      expect(user_clone_2.get_forced_decision('x')).to be_nil
-      expect(user_clone_2.get_forced_decision('a', '')).to eq('e')
+      expect(user_clone_2.get_forced_decision(context_with_flag)).to eq(decision_for_flag)
+      expect(user_clone_2.get_forced_decision(context_with_rule)).to eq(decision_for_rule)
+      expect(user_clone_2.get_forced_decision(unassigned_context)).to be_nil
+      expect(user_clone_2.get_forced_decision(context_with_empty_rule)).to eq(decision_for_empty_rule)
 
+      context_with_rule = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new('a', 'new-rk')
+      decision_for_rule = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('new-vk')
       # forced decisions should be copied separately
-      user_context_obj.set_forced_decision('a', 'new-rk', 'new-vk')
-      expect(user_context_obj.get_forced_decision('a', 'new-rk')).to eq('new-vk')
-      expect(user_clone_2.get_forced_decision('a', 'new-rk')).to be_nil
+      user_context_obj.set_forced_decision(context_with_rule, decision_for_rule)
+      expect(user_context_obj.get_forced_decision(context_with_rule)).to eq(decision_for_rule)
+      expect(user_clone_2.get_forced_decision(context_with_rule)).to be_nil
     end
 
     it 'should set, get, remove, remove all and clone in synchronize manner' do
@@ -571,6 +630,12 @@ describe 'Optimizely' do
       allow(user_context_obj).to receive(:remove_forced_decision)
       allow(user_context_obj).to receive(:remove_all_forced_decision)
 
+      context_with_flag_1 = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new('0', nil)
+      decision_for_flag_1 = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('var')
+
+      context_with_flag_2 = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new('1', nil)
+      decision_for_flag_2 = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('var')
+
       # clone
       threads << Thread.new do
         100.times do
@@ -581,39 +646,39 @@ describe 'Optimizely' do
       # set forced decision
       threads << Thread.new do
         100.times do
-          user_context_obj.set_forced_decision('0', nil, 'var')
+          user_context_obj.set_forced_decision(context_with_flag_1, decision_for_flag_1)
         end
       end
 
       threads << Thread.new do
         100.times do
-          user_context_obj.set_forced_decision('1', nil, 'var')
+          user_context_obj.set_forced_decision(context_with_flag_2, decision_for_flag_2)
         end
       end
 
       # get forced decision
       threads << Thread.new do
         100.times do
-          user_context_obj.get_forced_decision('0', nil)
+          user_context_obj.get_forced_decision(context_with_flag_1)
         end
       end
 
       threads << Thread.new do
         100.times do
-          user_context_obj.get_forced_decision('1', nil)
+          user_context_obj.get_forced_decision(context_with_flag_2)
         end
       end
 
       # remove forced decision
       threads << Thread.new do
         100.times do
-          user_context_obj.remove_forced_decision('0', nil)
+          user_context_obj.remove_forced_decision(context_with_flag_1)
         end
       end
 
       threads << Thread.new do
         100.times do
-          user_context_obj.remove_forced_decision('1', nil)
+          user_context_obj.remove_forced_decision(context_with_flag_2)
         end
       end
 
@@ -624,12 +689,12 @@ describe 'Optimizely' do
 
       threads.each(&:join)
       expect(user_context_obj).to have_received(:clone).exactly(100).times
-      expect(user_context_obj).to have_received(:set_forced_decision).with('0', nil, 'var').exactly(100).times
-      expect(user_context_obj).to have_received(:set_forced_decision).with('1', nil, 'var').exactly(100).times
-      expect(user_context_obj).to have_received(:get_forced_decision).with('0', nil).exactly(100).times
-      expect(user_context_obj).to have_received(:get_forced_decision).with('1', nil).exactly(100).times
-      expect(user_context_obj).to have_received(:remove_forced_decision).with('0', nil).exactly(100).times
-      expect(user_context_obj).to have_received(:remove_forced_decision).with('1', nil).exactly(100).times
+      expect(user_context_obj).to have_received(:set_forced_decision).with(context_with_flag_1, decision_for_flag_1).exactly(100).times
+      expect(user_context_obj).to have_received(:set_forced_decision).with(context_with_flag_2, decision_for_flag_2).exactly(100).times
+      expect(user_context_obj).to have_received(:get_forced_decision).with(context_with_flag_1).exactly(100).times
+      expect(user_context_obj).to have_received(:get_forced_decision).with(context_with_flag_2).exactly(100).times
+      expect(user_context_obj).to have_received(:remove_forced_decision).with(context_with_flag_1).exactly(100).times
+      expect(user_context_obj).to have_received(:remove_forced_decision).with(context_with_flag_2).exactly(100).times
       expect(user_context_obj).to have_received(:remove_all_forced_decision).once
     end
   end

--- a/spec/optimizely_user_context_spec.rb
+++ b/spec/optimizely_user_context_spec.rb
@@ -573,6 +573,25 @@ describe 'Optimizely' do
       expect(status).to be false
     end
 
+    it 'should return valid variation for duplicate OptimizelyDecisionContext in forced decision' do
+      user_id = 'tester'
+      feature_key = 'feature_1'
+      original_attributes = {}
+      stub_request(:post, impression_log_url)
+      user_context_obj = Optimizely::OptimizelyUserContext.new(forced_decision_project_instance, user_id, original_attributes)
+
+      context_with_rule = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, 'r')
+      decision_for_rule = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('ev1')
+
+      context_with_rule_dup = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, 'r')
+      decision_for_rule_dup = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('dupv1')
+
+      user_context_obj.set_forced_decision(context_with_rule, decision_for_rule)
+      user_context_obj.set_forced_decision(context_with_rule_dup, decision_for_rule_dup)
+
+      expect(user_context_obj.get_forced_decision(context_with_rule)).to eq(decision_for_rule_dup)
+    end
+
     it 'should clone forced decision in user context' do
       user_id = 'tester'
       original_attributes = {'country' => 'us'}


### PR DESCRIPTION
## Summary
- Updated forced-decision API request parameters.
- Added `OptimizelyDecisionContext` and `OptimizelyForcedDecision` structs.

## Testing
- All existing unit test should pass.
- All FSC cases should pass. 