### PR TITLE
fix(ForcedDecision): remove config-ready check from forced-decision apis

### DIFF
--- a/lib/optimizely/optimizely_user_context.rb
+++ b/lib/optimizely/optimizely_user_context.rb
@@ -103,7 +103,6 @@ module Optimizely
 
     def set_forced_decision(context, decision)
       flag_key = context[:flag_key]
-      return false if @optimizely_client&.get_optimizely_config.nil?
       return false if flag_key.nil?
 
       @forced_decision_mutex.synchronize { @forced_decisions[context] = decision }
@@ -126,8 +125,6 @@ module Optimizely
     # @return - A variation key or nil if forced decisions are not set for the parameters.
 
     def get_forced_decision(context)
-      return nil if @optimizely_client&.get_optimizely_config.nil?
-
       find_forced_decision(context)
     end
 
@@ -138,8 +135,6 @@ module Optimizely
     # @return - true if the forced decision has been removed successfully.
 
     def remove_forced_decision(context)
-      return false if @optimizely_client&.get_optimizely_config.nil?
-
       deleted = false
       @forced_decision_mutex.synchronize do
         if @forced_decisions.key?(context)
@@ -155,8 +150,6 @@ module Optimizely
     # @return - true if forced decisions have been removed successfully.
 
     def remove_all_forced_decision
-      return false if @optimizely_client&.get_optimizely_config.nil?
-
       @forced_decision_mutex.synchronize { @forced_decisions.clear }
       true
     end

--- a/spec/optimizely_user_context_spec.rb
+++ b/spec/optimizely_user_context_spec.rb
@@ -85,24 +85,6 @@ describe 'Optimizely' do
   end
 
   describe '#forced_decisions' do
-    it 'should return invalid status for invalid datafile in forced decision calls' do
-      user_id = 'test_user'
-      original_attributes = {}
-      invalid_project_instance = Optimizely::Project.new('Invalid datafile', nil, spy_logger, error_handler)
-      user_context_obj = Optimizely::OptimizelyUserContext.new(invalid_project_instance, user_id, original_attributes)
-      context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new('feature_1', nil)
-      decision = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('3324490562')
-
-      status = user_context_obj.set_forced_decision(context, decision)
-      expect(status).to be false
-      status = user_context_obj.get_forced_decision(context)
-      expect(status).to be_nil
-      status = user_context_obj.remove_forced_decision(context)
-      expect(status).to be false
-      status = user_context_obj.remove_all_forced_decision
-      expect(status).to be false
-    end
-
     it 'should return status for datafile in forced decision calls' do
       user_id = 'test_user'
       original_attributes = {}


### PR DESCRIPTION
## Summary
- Remove config-ready check from forced-decision apis

## Test plan
- Unit and FSC tests