### PR TITLE
enhancement: Generate OptimizelyConfig object on API Call instead of SDK initialization

### DIFF
--- a/lib/optimizely/config_manager/http_project_config_manager.rb
+++ b/lib/optimizely/config_manager/http_project_config_manager.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2019-2020, Optimizely and contributors
+#    Copyright 2019-2020, 2022, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/config_manager/static_project_config_manager.rb
+++ b/lib/optimizely/config_manager/static_project_config_manager.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2019-2020, Optimizely and contributors
+#    Copyright 2019-2020, 2022, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/config_manager/static_project_config_manager.rb
+++ b/lib/optimizely/config_manager/static_project_config_manager.rb
@@ -23,7 +23,7 @@ require_relative 'project_config_manager'
 module Optimizely
   class StaticProjectConfigManager < ProjectConfigManager
     # Implementation of ProjectConfigManager interface.
-    attr_reader :config, :optimizely_config
+    attr_reader :config
 
     def initialize(datafile, logger, error_handler, skip_json_validation)
       # Looks up and sets datafile and config based on response body.
@@ -40,8 +40,13 @@ module Optimizely
         error_handler,
         skip_json_validation
       )
+      @optimizely_config = nil
+    end
 
-      @optimizely_config = @config.nil? ? nil : OptimizelyConfig.new(@config).config
+    def optimizely_config
+      @optimizely_config = OptimizelyConfig.new(@config).config if @optimizely_config.nil?
+
+      @optimizely_config
     end
   end
 end


### PR DESCRIPTION
## Summary
`OptimizelyConfig` object is generated when SDK is being initialized. This operation is heavy and blocks the SDK from initializing quickly. This object is only used when users explicitly access it using `get_optimizely_config` API call. This PR moves the creation of this object from SDK initialization to the actual API call.

## Test plan
- Manually tested thoroughly
- All unit tests pass
- All FSC tests pass

## Issues
fixes #295 
