### PR TITLE
Updating dev doc URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 This repository houses the Ruby SDK for use with Optimizely Full Stack and Optimizely Rollouts.
 
-Optimizely Full Stack is A/B testing and feature flag management for product development teams. Experiment in any application. Make every feature on your roadmap an opportunity to learn. Learn more at https://www.optimizely.com/platform/full-stack/, or see the [documentation](https://docs.developers.optimizely.com/full-stack/docs).
+Optimizely Full Stack is A/B testing and feature flag management for product development teams. Experiment in any application. Make every feature on your roadmap an opportunity to learn. Learn more at https://www.optimizely.com/platform/full-stack/, or see the [documentation](https://docs.developers.optimizely.com/experimentation/v4.0.0-full-stack/docs/welcome).
 
-Optimizely Rollouts is free feature flags for development teams. Easily roll out and roll back features in any application without code deploys. Mitigate risk for every feature on your roadmap. Learn more at https://www.optimizely.com/rollouts/, or see the [documentation](https://docs.developers.optimizely.com/rollouts/docs).
+Optimizely Rollouts is free feature flags for development teams. Easily roll out and roll back features in any application without code deploys. Mitigate risk for every feature on your roadmap. Learn more at https://www.optimizely.com/rollouts/, or see the [documentation](https://docs.developers.optimizely.com/experimentation/v3.1.0-full-stack/docs/introduction-to-rollouts).
 
 ## Getting Started
 
@@ -176,7 +176,7 @@ If you enable event batching, make sure that you call the `close` method, `optim
 | -- | --
 | `close()` | Stops all timers and flushes the event queue. This method will also stop any timers that are happening for the datafile manager.
 
-See the Optimizely Full Stack [developer documentation](http://developers.optimizely.com/server/reference/index.html) to learn how to set up your first Full Stack project and use the SDK.
+See the Optimizely Full Stack Ruby SDK [developer documentation](https://docs.developers.optimizely.com/experimentation/v4.0.0-full-stack/docs/ruby-sdk) to learn how to set up your first Full Stack project and use the Ruby SDK.
 
 ## Development
 


### PR DESCRIPTION
## Summary
Updating documentation URLs in the ReadMe.

The "why", or other context.
As part of the larger Optimizely documentation consolidation, the URLs of the developer documentation have been changed.

## Test plan
N/A

## Issues
N/A
