### PR TITLE
feat: add odp event manager

### DIFF
--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -385,7 +385,8 @@ module Optimizely
       ODP_LOGS = {
         FETCH_SEGMENTS_FAILED: 'Audience segments fetch failed (%s).',
         ODP_EVENT_FAILED: 'ODP event send failed (%s).',
-        ODP_NOT_ENABLED: 'ODP is not enabled.'
+        ODP_NOT_ENABLED: 'ODP is not enabled.',
+        ODP_NOT_INTEGRATED: 'ODP is not integrated.'
       }.freeze
 
       DECISION_NOTIFICATION_TYPES = {
@@ -428,6 +429,13 @@ module Optimizely
         UNDETERMINED: 'UNDETERMINED',
         INTEGRATED: 'INTEGRATED',
         NOT_INTEGRATED: 'NOT_INTEGRATED'
+      }.freeze
+
+      ODP_EVENT_MANAGER = {
+        DEFAULT_QUEUE_CAPACITY: 10_000,
+        DEFAULT_BATCH_SIZE: 10,
+        DEFAULT_FLUSH_INTERVAL: 1,
+        DEFAULT_RETRY_COUNT: 3
       }.freeze
 
       HTTP_HEADERS = {

--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -434,7 +434,7 @@ module Optimizely
       ODP_EVENT_MANAGER = {
         DEFAULT_QUEUE_CAPACITY: 10_000,
         DEFAULT_BATCH_SIZE: 10,
-        DEFAULT_FLUSH_INTERVAL: 1,
+        DEFAULT_FLUSH_INTERVAL_SECONDS: 1,
         DEFAULT_RETRY_COUNT: 3
       }.freeze
 

--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -424,6 +424,12 @@ module Optimizely
         REQUEST_TIMEOUT: 10
       }.freeze
 
+      ODP_CONFIG_STATE = {
+        UNDETERMINED: 'UNDETERMINED',
+        INTEGRATED: 'INTEGRATED',
+        NOT_INTEGRATED: 'NOT_INTEGRATED'
+      }.freeze
+
       HTTP_HEADERS = {
         'IF_MODIFIED_SINCE' => 'If-Modified-Since',
         'LAST_MODIFIED' => 'Last-Modified'

--- a/lib/optimizely/helpers/validator.rb
+++ b/lib/optimizely/helpers/validator.rb
@@ -178,6 +178,11 @@ module Optimizely
 
         value.is_a?(Numeric) && value.to_f.finite? && value.abs <= Constants::FINITE_NUMBER_LIMIT
       end
+
+      def odp_data_types_valid?(data)
+        valid_types = [String, Float, Integer, TrueClass, FalseClass, NilClass]
+        data.values.all? { |e| valid_types.member? e.class }
+      end
     end
   end
 end

--- a/lib/optimizely/odp/odp_config.rb
+++ b/lib/optimizely/odp/odp_config.rb
@@ -32,7 +32,7 @@ module Optimizely
       @api_host = api_host
       @segments_to_check = segments_to_check
       @mutex = Mutex.new
-      @odp_state = @api_host.nil? && @api_key.nil? ? ODP_CONFIG_STATE[:UNDETERMINED] : ODP_CONFIG_STATE[:INTEGRATED]
+      @odp_state = @api_host.nil? || @api_key.nil? ? ODP_CONFIG_STATE[:UNDETERMINED] : ODP_CONFIG_STATE[:INTEGRATED]
     end
 
     # Replaces the existing configuration
@@ -46,7 +46,7 @@ module Optimizely
     def update(api_key = nil, api_host = nil, segments_to_check = [])
       updated = false
       @mutex.synchronize do
-        @odp_state = api_host.nil? && api_key.nil? ? ODP_CONFIG_STATE[:NOT_INTEGRATED] : ODP_CONFIG_STATE[:INTEGRATED]
+        @odp_state = api_host.nil? || api_key.nil? ? ODP_CONFIG_STATE[:NOT_INTEGRATED] : ODP_CONFIG_STATE[:INTEGRATED]
 
         if @api_key != api_key || @api_host != api_host || @segments_to_check != segments_to_check
           @api_key = api_key

--- a/lib/optimizely/odp/odp_config.rb
+++ b/lib/optimizely/odp/odp_config.rb
@@ -17,9 +17,11 @@
 #
 
 require 'optimizely/logger'
+require_relative '../helpers/constants'
 
 module Optimizely
   class OdpConfig
+    ODP_CONFIG_STATE = Helpers::Constants::ODP_CONFIG_STATE
     # Contains configuration used for ODP integration.
     #
     # @param api_host - The host URL for the ODP audience segments API (optional).
@@ -30,6 +32,7 @@ module Optimizely
       @api_host = api_host
       @segments_to_check = segments_to_check
       @mutex = Mutex.new
+      @odp_state = @api_host.nil? && @api_key.nil? ? ODP_CONFIG_STATE[:UNDETERMINED] : ODP_CONFIG_STATE[:INTEGRATED]
     end
 
     # Replaces the existing configuration
@@ -41,14 +44,19 @@ module Optimizely
     # @return - True if the provided values were different than the existing values.
 
     def update(api_key = nil, api_host = nil, segments_to_check = [])
+      updated = false
       @mutex.synchronize do
-        break false if @api_key == api_key && @api_host == api_host && @segments_to_check == segments_to_check
+        @odp_state = api_host.nil? && api_key.nil? ? ODP_CONFIG_STATE[:NOT_INTEGRATED] : ODP_CONFIG_STATE[:INTEGRATED]
 
-        @api_key = api_key
-        @api_host = api_host
-        @segments_to_check = segments_to_check
-        break true
+        if @api_key != api_key || @api_host != api_host || @segments_to_check != segments_to_check
+          @api_key = api_key
+          @api_host = api_host
+          @segments_to_check = segments_to_check
+          updated = true
+        end
       end
+
+      updated
     end
 
     # Returns the api host for odp connections
@@ -99,12 +107,12 @@ module Optimizely
       @mutex.synchronize { @segments_to_check = segments_to_check.clone }
     end
 
-    # Returns True if odp is integrated
+    # Returns the state of odp integration (UNDETERMINED, INTEGRATED, NOT_INTEGRATED)
     #
-    # @return - bool
+    # @return - string
 
-    def odp_integrated?
-      @mutex.synchronize { !@api_key.nil? && !@api_host.nil? }
+    def odp_state
+      @mutex.synchronize { @odp_state }
     end
   end
 end

--- a/lib/optimizely/odp/odp_event.rb
+++ b/lib/optimizely/odp/odp_event.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#
+#    Copyright 2022, Optimizely and contributors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'json'
+
+module Optimizely
+  class OdpEvent
+    # Representation of an odp event which can be sent to the Optimizely odp platform.
+    def initialize(type:, action:, identifiers:, data:)
+      @type = type
+      @action = action
+      @identifiers = identifiers
+      @data = add_common_event_data(data)
+    end
+
+    def add_common_event_data(custom_data)
+      data = {
+        idempotence_id: SecureRandom.uuid,
+        data_source_type: 'sdk',
+        data_source: 'ruby-sdk',
+        data_source_version: VERSION
+      }
+      data.update(custom_data)
+      data
+    end
+
+    def to_json(*_args)
+      {
+        type: @type,
+        action: @action,
+        identifiers: @identifiers,
+        data: @data
+      }.to_json
+    end
+
+    def ==(other)
+      to_json == other.to_json
+    end
+  end
+end

--- a/lib/optimizely/odp/odp_event_manager.rb
+++ b/lib/optimizely/odp/odp_event_manager.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+#
+#    Copyright 2019, 2022, Optimizely and contributors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+require_relative 'zaius_rest_api_manager'
+require_relative '../helpers/constants'
+
+module Optimizely
+  class OdpEventManager
+    # BatchEventProcessor is a batched implementation of the Interface EventProcessor.
+    # Events passed to the BatchEventProcessor are immediately added to an EventQueue.
+    # The BatchEventProcessor maintains a single consumer thread that pulls events off of
+    # the BlockingQueue and buffers them for either a configured batch size or for a
+    # maximum duration before the resulting LogEvent is sent to the NotificationCenter.
+
+    attr_reader :batch_size, :odp_config, :zaius_manager, :logger
+
+    def initialize(
+      odp_config,
+      api_manager: nil,
+      logger: NoOpLogger.new,
+      proxy_config: nil
+    )
+      super()
+      @odp_config = odp_config
+      @mutex = Mutex.new
+      @event_queue = SizedQueue.new(Optimizely::Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_QUEUE_CAPACITY])
+      @queue_capacity = Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_QUEUE_CAPACITY]
+      # received signal should be sent after adding item to event_queue
+      @received = ConditionVariable.new
+      @logger = logger
+      @zaius_manager = api_manager || ZaiusRestApiManager.new(logger: @logger, proxy_config: proxy_config)
+      @batch_size = Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_BATCH_SIZE]
+      @flush_interval = Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_FLUSH_INTERVAL]
+      @flush_deadline = 0
+      @retry_count = Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_RETRY_COUNT]
+      # current_batch should only be accessed by processing thread
+      @current_batch = []
+      @thread_exception = false
+    end
+
+    def start!
+      if running?
+        @logger.log(Logger::WARN, 'Service already started.')
+        return
+      end
+      @thread = Thread.new { run }
+      @logger.log(Logger::INFO, 'Starting scheduler.')
+    end
+
+    def flush
+      begin
+        @event_queue.push(:FLUSH_SIGNAL, non_block: true)
+      rescue ThreadError
+        @logger.log(Logger::ERROR, 'Error flushing ODP event queue.')
+        return
+      end
+
+      @mutex.synchronize do
+        @received.signal
+      end
+    end
+
+    def dispatch(event)
+      if @thread_exception
+        @logger.log(Logger::ERROR, format(Helpers::Constants::ODP_LOGS[:ODP_EVENT_FAILED], 'Queue is down'))
+        return
+      end
+
+      # if the processor has been explicitly stopped. Don't accept tasks
+      unless running?
+        @logger.log(Logger::WARN, 'ODP event queue is shutdown, not accepting events.')
+        return
+      end
+
+      begin
+        @logger.log(Logger::DEBUG, 'ODP event queue: adding event.')
+        @event_queue.push(event, non_block: true)
+      rescue => e
+        @logger.log(Logger::WARN, format(Helpers::Constants::ODP_LOGS[:ODP_EVENT_FAILED], e.message))
+        return
+      end
+
+      @mutex.synchronize do
+        @received.signal
+      end
+    end
+
+    def send_event(type:, action:, identifiers:, data:)
+      case @odp_config.odp_state
+      when OdpConfig::ODP_CONFIG_STATE[:UNDETERMINED]
+        @logger.log(Logger::DEBUG, 'ODP event queue: cannot send before the datafile has loaded.')
+        return
+      when OdpConfig::ODP_CONFIG_STATE[:NOT_INTEGRATED]
+        @logger.log(Logger::DEBUG, Helpers::Constants::ODP_LOGS[:ODP_NOT_INTEGRATED])
+        return
+      end
+
+      event = Optimizely::OdpEvent.new(type: type, action: action, identifiers: identifiers, data: data)
+      dispatch(event)
+    end
+
+    def stop!
+      return unless running?
+
+      begin
+        @event_queue.push(:SHUTDOWN_SIGNAL, non_block: true)
+      rescue ThreadError
+        @logger.log(Logger::ERROR, 'Error stopping ODP event queue.')
+        return
+      end
+
+      @mutex.synchronize do
+        @received.signal
+      end
+
+      @logger.log(Logger::INFO, 'Stopping ODP event queue.')
+
+      @thread.join
+
+      @logger.log(Logger::ERROR, format(Helpers::Constants::ODP_LOGS[:ODP_EVENT_FAILED], @current_batch.to_json)) unless @current_batch.empty?
+    end
+
+    def running?
+      @thread && !!@thread.status
+    end
+
+    private
+
+    def run
+      loop do
+        @mutex.synchronize do
+          @received.wait(@mutex, queue_timeout) if @event_queue.empty?
+        end
+
+        begin
+          item = @event_queue.pop(non_block: true)
+        rescue ThreadError => e
+          raise unless e.message == 'queue empty'
+
+          item = nil
+        end
+
+        case item
+        when :SHUTDOWN_SIGNAL
+          @logger.log(Logger::DEBUG, 'ODP event queue: received shutdown signal.')
+          break
+
+        when :FLUSH_SIGNAL
+          @logger.log(Logger::DEBUG, 'ODP event queue: received flush signal.')
+          flush_batch!
+          next
+
+        when Optimizely::OdpEvent
+          add_to_batch(item)
+        when nil && !@current_batch.empty?
+          @logger.log(Logger::DEBUG, 'ODP event queue: flushing on interval.')
+          flush_batch!
+        end
+      end
+    rescue SignalException
+      @thread_exception = true
+      @logger.log(Logger::ERROR, 'Interrupted while processing ODP events.')
+    rescue => e
+      @thread_exception = true
+      @logger.log(Logger::ERROR, "Uncaught exception processing ODP events. Error: #{e.message}")
+    ensure
+      @logger.log(Logger::INFO, 'Exiting ODP processing loop. Attempting to flush pending events.')
+      flush_batch!
+    end
+
+    def flush_batch!
+      if @current_batch.empty?
+        @logger.log(Logger::DEBUG, 'ODP event queue: nothing to flush.')
+        return
+      end
+
+      api_key = @odp_config.api_key
+      api_host = @odp_config.api_host
+
+      if api_key.nil? || api_host.nil?
+        @logger.log(Logger::DEBUG, Helpers::Constants::ODP_LOGS[:ODP_NOT_INTEGRATED])
+        @current_batch.clear
+        return
+      end
+
+      @logger.log(Logger::DEBUG, "ODP event queue: flushing batch size #{@current_batch.length}.")
+      should_retry = false
+
+      i = 0
+      while i < @retry_count
+        begin
+          should_retry = @zaius_manager.send_odp_events(api_key, api_host, @current_batch)
+        rescue StandardError => e
+          should_retry = false
+          @logger.log(Logger::ERROR, format(Helpers::Constants::ODP_LOGS[:ODP_EVENT_FAILED], "Error: #{e.message} #{@current_batch.to_json}"))
+        end
+        break unless should_retry
+
+        @logger.log(Logger::DEBUG, 'Error dispatching ODP events, scheduled to retry.') if i < @retry_count
+        i += 1
+      end
+
+      @logger.log(Logger::ERROR, format(Helpers::Constants::ODP_LOGS[:ODP_EVENT_FAILED], "Failed after #{i} retries: #{@current_batch.to_json}")) if should_retry
+
+      @current_batch.clear
+    end
+
+    def add_to_batch(event)
+      set_flush_deadline if @current_batch.empty?
+
+      @current_batch << event
+      return unless @current_batch.length >= @batch_size
+
+      @logger.log(Logger::DEBUG, 'ODP event queue: flushing on batch size.')
+      flush_batch!
+    end
+
+    def set_flush_deadline
+      # Sets time that next flush will occur.
+      @flush_deadline = Time.new + @flush_interval
+    end
+
+    def time_till_flush
+      # Returns seconds until next flush; no less than 0.
+      [0, @flush_deadline - Time.new].max
+    end
+
+    def queue_timeout
+      # Returns seconds until next flush or None if current batch is empty.
+      return nil if @current_batch.empty?
+
+      time_till_flush
+    end
+  end
+end

--- a/lib/optimizely/odp/odp_event_manager.rb
+++ b/lib/optimizely/odp/odp_event_manager.rb
@@ -44,7 +44,7 @@ module Optimizely
       @logger = logger
       @zaius_manager = api_manager || ZaiusRestApiManager.new(logger: @logger, proxy_config: proxy_config)
       @batch_size = Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_BATCH_SIZE]
-      @flush_interval = Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_FLUSH_INTERVAL]
+      @flush_interval = Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_FLUSH_INTERVAL_SECONDS]
       @flush_deadline = 0
       @retry_count = Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_RETRY_COUNT]
       # current_batch should only be accessed by processing thread
@@ -123,6 +123,8 @@ module Optimizely
         return
       end
 
+      @event_queue.close
+
       @mutex.synchronize do
         @received.signal
       end
@@ -135,7 +137,7 @@ module Optimizely
     end
 
     def running?
-      @thread && !!@thread.status
+      @thread && !!@thread.status && !@event_queue.closed?
     end
 
     private

--- a/lib/optimizely/odp/odp_segment_manager.rb
+++ b/lib/optimizely/odp/odp_segment_manager.rb
@@ -66,9 +66,10 @@ module Optimizely
           @logger.log(Logger::DEBUG, 'ODP cache hit. Returning segments from cache.')
           return segments
         end
+        @logger.log(Logger::DEBUG, 'ODP cache miss.')
       end
 
-      @logger.log(Logger::DEBUG, 'ODP cache miss. Making a call to ODP server.')
+      @logger.log(Logger::DEBUG, 'Making a call to ODP server.')
 
       segments = @zaius_manager.fetch_segments(odp_api_key, odp_api_host, user_key, user_value, segments_to_check)
       @segments_cache.save(cache_key, segments) unless segments.nil? || ignore_cache

--- a/lib/optimizely/odp/odp_segment_manager.rb
+++ b/lib/optimizely/odp/odp_segment_manager.rb
@@ -39,14 +39,14 @@ module Optimizely
     #
     # @return - Array of qualified segments.
     def fetch_qualified_segments(user_key, user_value, options)
-      unless @odp_config.odp_integrated?
-        @logger.log(Logger::ERROR, format(Optimizely::Helpers::Constants::ODP_LOGS[:FETCH_SEGMENTS_FAILED], 'ODP is not enabled'))
-        return nil
-      end
-
       odp_api_key = @odp_config.api_key
       odp_api_host = @odp_config.api_host
       segments_to_check = @odp_config&.segments_to_check
+
+      if odp_api_key.nil? || odp_api_host.nil?
+        @logger.log(Logger::ERROR, format(Optimizely::Helpers::Constants::ODP_LOGS[:FETCH_SEGMENTS_FAILED], 'ODP is not enabled'))
+        return nil
+      end
 
       unless segments_to_check&.size&.positive?
         @logger.log(Logger::DEBUG, 'No segments are used in the project. Returning empty list')

--- a/spec/odp/odp_event_manager_spec.rb
+++ b/spec/odp/odp_event_manager_spec.rb
@@ -352,6 +352,8 @@ describe Optimizely::OdpEventManager do
       event[:data][:data_source] = 'my-app'
       odp_event = Optimizely::OdpEvent.new(**event)
 
+      expect(odp_event.instance_variable_get('@data')[:data_source]).to eq 'my-app'
+
       allow(event_manager.zaius_manager).to receive(:send_odp_events).once.with(api_key, api_host, [odp_event]).and_return(false)
       event_manager.start!
 

--- a/spec/odp/odp_event_manager_spec.rb
+++ b/spec/odp/odp_event_manager_spec.rb
@@ -1,0 +1,486 @@
+# frozen_string_literal: true
+
+# Copyright 2022, Optimizely
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require 'spec_helper'
+require 'optimizely/odp/odp_event_manager'
+require 'optimizely/odp/odp_event'
+require 'optimizely/odp/lru_cache'
+require 'optimizely/odp/odp_config'
+require 'optimizely/odp/zaius_rest_api_manager'
+require 'optimizely/logger'
+require 'optimizely/helpers/validator'
+
+describe Optimizely::OdpEventManager do
+  let(:spy_logger) { spy('logger') }
+  let(:api_host) { 'https://test-host' }
+  let(:user_key) { 'fs_user_id' }
+  let(:user_value) { 'test-user-value' }
+  let(:api_key) { 'test-api-key' }
+  let(:segments_to_check) { %w[a b c] }
+  let(:odp_config) { Optimizely::OdpConfig.new(api_key, api_host) }
+  let(:test_uuid) { SecureRandom.uuid }
+  let(:version) { Optimizely::VERSION }
+  let(:events) do
+    [
+      {type: 't1', action: 'a1', identifiers: {'id-key-1': 'id-value-1'}, data: {'key-1': 'value1', "key-2": 2, "key-3": 3.0, "key-4": nil, 'key-5': true, 'key-6': false}},
+      {type: 't2', action: 'a2', identifiers: {'id-key-2': 'id-value-2'}, data: {'key-2': 'value2'}}
+    ]
+  end
+  let(:processed_events) do
+    [
+      {
+        type: 't1',
+        action: 'a1',
+        identifiers: {'id-key-1': 'id-value-1'},
+        data: {
+          idempotence_id: test_uuid,
+          data_source_type: 'sdk',
+          data_source: 'ruby-sdk',
+          data_source_version: version,
+          'key-1': 'value1',
+          "key-2": 2,
+          "key-3": 3.0,
+          "key-4": nil,
+          "key-5": true,
+          "key-6": false
+        }
+      },
+      {
+        type: 't2',
+        action: 'a2',
+        identifiers: {'id-key-2': 'id-value-2'},
+        data: {
+          idempotence_id: test_uuid,
+          data_source_type: 'sdk',
+          data_source: 'ruby-sdk',
+          data_source_version: version,
+          'key-2': 'value2'
+        }
+      }
+    ]
+  end
+  let(:odp_events) do
+    [
+      Optimizely::OdpEvent.new(**events[0]),
+      Optimizely::OdpEvent.new(**events[1])
+    ]
+  end
+
+  describe 'OdpEvent#initialize' do
+    it 'should return proper OdpEvent' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      event = events[0]
+      expect(Optimizely::Helpers::Validator.odp_data_types_valid?(event[:data])).to be true
+
+      odp_event = Optimizely::OdpEvent.new(**event)
+      expect(odp_event.to_json).to be == processed_events[0].to_json
+    end
+
+    it 'should fail with invalid event' do
+      event = events[0]
+      event[:data]['invalid-item'] = {}
+      expect(Optimizely::Helpers::Validator.odp_data_types_valid?(event[:data])).to be false
+    end
+  end
+
+  describe '#initialize' do
+    it 'should return OdpEventManager instance' do
+      config = Optimizely::OdpConfig.new
+
+      api_manager = Optimizely::ZaiusRestApiManager.new
+      event_manager = Optimizely::OdpEventManager.new(config, api_manager: api_manager, logger: spy_logger)
+
+      expect(event_manager.odp_config).to be config
+      expect(event_manager.zaius_manager).to be api_manager
+      expect(event_manager.logger).to be spy_logger
+
+      event_manager = Optimizely::OdpEventManager.new(config)
+      expect(event_manager.logger).to be_a Optimizely::NoOpLogger
+      expect(event_manager.zaius_manager).to be_a Optimizely::ZaiusRestApiManager
+    end
+  end
+
+  describe '#event processing' do
+    it 'should process events successfully' do
+      stub_request(:post, "#{api_host}/v3/events")
+        .to_return(status: 200)
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      event_manager.start!
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+      event_manager.stop!
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+      expect(spy_logger).to have_received(:log).with(Logger::DEBUG, 'ODP event queue: flushing batch size 2.')
+      expect(spy_logger).to have_received(:log).with(Logger::DEBUG, 'ODP event queue: received shutdown signal.')
+      expect(event_manager.running?).to be false
+    end
+
+    it 'should flush at batch size' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      allow(event_manager.zaius_manager).to receive(:send_odp_events).and_return(false)
+      event_manager.start!
+
+      event_manager.instance_variable_set('@batch_size', 2)
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+      expect(spy_logger).to have_received(:log).with(Logger::DEBUG, 'ODP event queue: flushing on batch size.')
+      event_manager.stop!
+    end
+
+    it 'should flush multiple batches' do
+      batch_count = 4
+
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      allow(event_manager.zaius_manager).to receive(:send_odp_events).exactly(batch_count).times.and_return(false)
+      event_manager.start!
+
+      event_manager.instance_variable_set('@batch_size', 2)
+
+      batch_count.times do
+        event_manager.send_event(**events[0])
+        event_manager.send_event(**events[1])
+      end
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+      expect(spy_logger).to have_received(:log).exactly(batch_count).times.with(Logger::DEBUG, 'ODP event queue: flushing on batch size.')
+      expect(spy_logger).to have_received(:log).exactly(batch_count).times.with(Logger::DEBUG, 'ODP event queue: flushing batch size 2.')
+
+      event_manager.stop!
+    end
+
+    it 'should process backlog successfully' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+
+      event_manager.instance_variable_set('@batch_size', 2)
+      batch_count = 4
+      allow(event_manager.zaius_manager).to receive(:send_odp_events).exactly(batch_count).times.with(api_key, api_host, odp_events).and_return(false)
+
+      # create events before starting processing to simulate backlog
+      allow(event_manager).to receive(:running?).and_return(true)
+      (batch_count - 1).times do
+        event_manager.send_event(**events[0])
+        event_manager.send_event(**events[1])
+      end
+      RSpec::Mocks.space.proxy_for(event_manager).remove_stub(:running?)
+      event_manager.start!
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+      event_manager.stop!
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+      expect(spy_logger).to have_received(:log).exactly(batch_count).times.with(Logger::DEBUG, 'ODP event queue: flushing on batch size.')
+      expect(spy_logger).to have_received(:log).exactly(batch_count).times.with(Logger::DEBUG, 'ODP event queue: flushing batch size 2.')
+    end
+
+    it 'should flush with flush signal' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      allow(event_manager.zaius_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
+      event_manager.start!
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+      event_manager.flush
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      expect(spy_logger).to have_received(:log).once.with(Logger::DEBUG, 'ODP event queue: received flush signal.')
+      event_manager.stop!
+    end
+
+    it 'should flush multiple times successfully' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      allow(event_manager.zaius_manager).to receive(:send_odp_events).exactly(4).times.with(api_key, api_host, odp_events).and_return(false)
+      event_manager.start!
+      flush_count = 4
+
+      flush_count.times do
+        event_manager.send_event(**events[0])
+        event_manager.send_event(**events[1])
+        event_manager.flush
+      end
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      expect(spy_logger).to have_received(:log).exactly(flush_count).times.with(Logger::DEBUG, 'ODP event queue: received flush signal.')
+      expect(spy_logger).to have_received(:log).exactly(flush_count).times.with(Logger::DEBUG, 'ODP event queue: flushing batch size 2.')
+
+      event_manager.stop!
+    end
+
+    it 'should log error on retry failure' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      retry_count = event_manager.instance_variable_get('@retry_count')
+      allow(event_manager.zaius_manager).to receive(:send_odp_events).exactly(retry_count + 1).times.with(api_key, api_host, odp_events).and_return(true)
+      event_manager.start!
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+      event_manager.flush
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      expect(spy_logger).to have_received(:log).exactly(retry_count).times.with(Logger::DEBUG, 'Error dispatching ODP events, scheduled to retry.')
+      expect(spy_logger).to have_received(:log).once.with(Logger::ERROR, "ODP event send failed (Failed after 3 retries: #{processed_events.to_json}).")
+
+      event_manager.stop!
+    end
+
+    it 'should retry on network failure' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      allow(event_manager.zaius_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(true, true, false)
+      event_manager.start!
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+      event_manager.flush
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      expect(spy_logger).to have_received(:log).twice.with(Logger::DEBUG, 'Error dispatching ODP events, scheduled to retry.')
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+      expect(event_manager.running?).to be true
+      event_manager.stop!
+    end
+
+    it 'should log error on send failure' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      allow(event_manager.zaius_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_raise(StandardError, 'Unexpected error')
+      event_manager.start!
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+      event_manager.flush
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      expect(spy_logger).to have_received(:log).once.with(Logger::ERROR, "ODP event send failed (Error: Unexpected error #{processed_events.to_json}).")
+      expect(event_manager.running?).to be true
+      event_manager.stop!
+    end
+
+    it 'should log debug when odp disabled' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      odp_config = Optimizely::OdpConfig.new
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      odp_config.update(nil, nil, nil)
+      event_manager.start!
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+      expect(spy_logger).to have_received(:log).twice.with(Logger::DEBUG, Optimizely::Helpers::Constants::ODP_LOGS[:ODP_NOT_INTEGRATED])
+      expect(event_manager.running?).to be true
+      event_manager.stop!
+    end
+
+    it 'should log error when queue is full' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      stub_const('Optimizely::Helpers::Constants::ODP_EVENT_MANAGER', {DEFAULT_QUEUE_CAPACITY: 1})
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      allow(event_manager).to receive(:running?).and_return(true)
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+      event_manager.flush
+
+      # warning when adding event to full queue
+      expect(spy_logger).to have_received(:log).once.with(Logger::WARN, 'ODP event send failed (queue full).')
+      # error when trying to flush with full queue
+      expect(spy_logger).to have_received(:log).once.with(Logger::ERROR, 'Error flushing ODP event queue.')
+    end
+
+    it 'should log error on exception within thread' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      allow(event_manager).to receive(:add_to_batch).and_raise(StandardError, 'Unexpected error')
+      event_manager.start!
+
+      event_manager.send_event(**events[0])
+      sleep(0.1)
+      event_manager.send_event(**events[0])
+
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+      expect(spy_logger).to have_received(:log).once.with(Logger::ERROR, 'Uncaught exception processing ODP events. Error: Unexpected error')
+      expect(spy_logger).to have_received(:log).once.with(Logger::ERROR, 'ODP event send failed (Queue is down).')
+
+      event_manager.stop!
+    end
+
+    it 'should work with overriden event data' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+
+      event = events[0]
+      event[:data][:data_source] = 'my-app'
+      odp_event = Optimizely::OdpEvent.new(**event)
+
+      allow(event_manager.zaius_manager).to receive(:send_odp_events).once.with(api_key, api_host, [odp_event]).and_return(false)
+      event_manager.start!
+
+      event_manager.send_event(**event)
+      event_manager.flush
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      event_manager.stop!
+    end
+
+    it 'should flush when timeout is reached' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      allow(event_manager.zaius_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
+      event_manager.instance_variable_set('@flush_interval', 0.5)
+      event_manager.start!
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+      sleep(1)
+
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+      expect(spy_logger).to have_received(:log).once.with(Logger::DEBUG, 'ODP event queue: flushing on interval.')
+      event_manager.stop!
+    end
+
+    it 'should discard events received before datafile is ready and process normally' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      odp_config = Optimizely::OdpConfig.new
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      allow(event_manager.zaius_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
+      event_manager.start!
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+
+      odp_config.update(api_key, api_host, [])
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+      event_manager.flush
+
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+      expect(spy_logger).to have_received(:log).twice.with(Logger::DEBUG, 'ODP event queue: cannot send before the datafile has loaded.')
+      expect(spy_logger).to have_received(:log).twice.with(Logger::DEBUG, 'ODP event queue: adding event.')
+      expect(spy_logger).to have_received(:log).once.with(Logger::DEBUG, 'ODP event queue: received flush signal.')
+      expect(spy_logger).to have_received(:log).once.with(Logger::DEBUG, 'ODP event queue: flushing batch size 2.')
+      event_manager.stop!
+    end
+
+    it 'should discard events before and after odp is disabled' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      odp_config = Optimizely::OdpConfig.new
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      expect(event_manager.zaius_manager).not_to receive(:send_odp_events)
+      event_manager.start!
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+
+      odp_config.update(nil, nil, [])
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+      expect(spy_logger).to have_received(:log).twice.with(Logger::DEBUG, 'ODP event queue: cannot send before the datafile has loaded.')
+      expect(spy_logger).to have_received(:log).twice.with(Logger::DEBUG, Optimizely::Helpers::Constants::ODP_LOGS[:ODP_NOT_INTEGRATED])
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      event_manager.stop!
+    end
+
+    it 'should begin discarding events if odp is disabled after being enabled' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      odp_config = Optimizely::OdpConfig.new(api_key, api_host)
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      allow(event_manager.zaius_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
+      event_manager.start!
+
+      event_manager.instance_variable_set('@batch_size', 2)
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      odp_config.update(nil, nil, [])
+
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+      expect(spy_logger).to have_received(:log).once.with(Logger::DEBUG, 'ODP event queue: flushing batch size 2.')
+      expect(spy_logger).to have_received(:log).twice.with(Logger::DEBUG, Optimizely::Helpers::Constants::ODP_LOGS[:ODP_NOT_INTEGRATED])
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      event_manager.stop!
+    end
+
+    it 'should discard events if odp is disabled after there are events in queue' do
+      odp_config = Optimizely::OdpConfig.new(api_key, api_host)
+
+      event_manager = Optimizely::OdpEventManager.new(odp_config, logger: spy_logger)
+      expect(event_manager.zaius_manager).not_to receive(:send_odp_events)
+      event_manager.instance_variable_set('@batch_size', 2)
+
+      allow(event_manager).to receive(:running?).and_return(true)
+      event_manager.send_event(**events[0])
+      event_manager.send_event(**events[1])
+
+      RSpec::Mocks.space.proxy_for(event_manager).remove_stub(:running?)
+
+      odp_config.update(nil, nil, [])
+      event_manager.start!
+      event_manager.send_event(**events[1])
+      sleep(0.1) until event_manager.instance_variable_get('@event_queue').empty?
+
+      expect(event_manager.instance_variable_get('@current_batch').length).to eq 0
+      expect(spy_logger).to have_received(:log).twice.with(Logger::DEBUG, Optimizely::Helpers::Constants::ODP_LOGS[:ODP_NOT_INTEGRATED])
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+      event_manager.stop!
+    end
+  end
+end


### PR DESCRIPTION
Summary
-------
OdpEventManager provides internal services for sending ODP events to the ODP server. 
- adds default values to identifiers and data fields for all events.
- stores requested events if they cannot be sent to the server.
- stored events are dispatched when resources are available.

Test plan
---------
- added odp_event_manager_spec.rb

Ticket
------
[OASIS-8445](https://optimizely.atlassian.net/browse/OASIS-8445)
