### PR TITLE
fix: fetch timeout made configurable

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -112,7 +112,7 @@ module Optimizely
         segment_manager: @sdk_settings.odp_segment_manager,
         event_manager: @sdk_settings.odp_event_manager,
         segments_cache: @sdk_settings.odp_segments_cache,
-        timeout: @sdk_settings.timeout,
+        fetch_segments_timeout: @sdk_settings.fetch_segments_timeout,
         logger: @logger
       )
 

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -112,6 +112,7 @@ module Optimizely
         segment_manager: @sdk_settings.odp_segment_manager,
         event_manager: @sdk_settings.odp_event_manager,
         segments_cache: @sdk_settings.odp_segments_cache,
+        timeout: @sdk_settings.timeout,
         logger: @logger
       )
 

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -113,6 +113,7 @@ module Optimizely
         event_manager: @sdk_settings.odp_event_manager,
         segments_cache: @sdk_settings.odp_segments_cache,
         fetch_segments_timeout: @sdk_settings.fetch_segments_timeout,
+        odp_event_timeout: @sdk_settings.odp_event_timeout,
         logger: @logger
       )
 

--- a/lib/optimizely/helpers/sdk_settings.rb
+++ b/lib/optimizely/helpers/sdk_settings.rb
@@ -39,7 +39,7 @@ module Optimizely
         odp_segments_cache: nil,
         odp_segment_manager: nil,
         odp_event_manager: nil,
-        fetch_segments_timeout: nil
+        fetch_segments_timeout: nil,
         odp_event_timeout: nil
       )
         @odp_disabled = disable_odp

--- a/lib/optimizely/helpers/sdk_settings.rb
+++ b/lib/optimizely/helpers/sdk_settings.rb
@@ -40,6 +40,7 @@ module Optimizely
         odp_segment_manager: nil,
         odp_event_manager: nil,
         fetch_segments_timeout: nil
+        odp_event_timeout: nil
       )
         @odp_disabled = disable_odp
         @segments_cache_size = segments_cache_size
@@ -48,6 +49,7 @@ module Optimizely
         @odp_segment_manager = odp_segment_manager
         @odp_event_manager = odp_event_manager
         @fetch_segments_timeout = fetch_segments_timeout
+        @odp_event_timeout = odp_event_timeout
       end
     end
   end

--- a/lib/optimizely/helpers/sdk_settings.rb
+++ b/lib/optimizely/helpers/sdk_settings.rb
@@ -21,7 +21,7 @@ require_relative 'constants'
 module Optimizely
   module Helpers
     class OptimizelySdkSettings
-      attr_accessor :odp_disabled, :segments_cache_size, :segments_cache_timeout_in_secs, :odp_segments_cache, :odp_segment_manager, :odp_event_manager
+      attr_accessor :odp_disabled, :segments_cache_size, :segments_cache_timeout_in_secs, :odp_segments_cache, :odp_segment_manager, :odp_event_manager, :fetch_segments_timeout
 
       # Contains configuration used for Optimizely Project initialization.
       #

--- a/lib/optimizely/helpers/sdk_settings.rb
+++ b/lib/optimizely/helpers/sdk_settings.rb
@@ -21,7 +21,7 @@ require_relative 'constants'
 module Optimizely
   module Helpers
     class OptimizelySdkSettings
-      attr_accessor :odp_disabled, :segments_cache_size, :segments_cache_timeout_in_secs, :odp_segments_cache, :odp_segment_manager, :odp_event_manager, :fetch_segments_timeout
+      attr_accessor :odp_disabled, :segments_cache_size, :segments_cache_timeout_in_secs, :odp_segments_cache, :odp_segment_manager, :odp_event_manager, :fetch_segments_timeout, :odp_event_timeout
 
       # Contains configuration used for Optimizely Project initialization.
       #

--- a/lib/optimizely/helpers/sdk_settings.rb
+++ b/lib/optimizely/helpers/sdk_settings.rb
@@ -32,7 +32,6 @@ module Optimizely
       # @param odp_segment_manager - A custom odp segment manager. Required method is: `fetch_qualified_segments(user_key, user_value, options)`.
       # @param odp_event_manager - A custom odp event manager. Required method is: `send_event(type:, action:, identifiers:, data:)`
       # @param fetch_segments_timeout - The timeout in seconds of to fetch odp segments (optional. default = 10).
-      
       def initialize(
         disable_odp: false,
         segments_cache_size: Constants::ODP_SEGMENTS_CACHE_CONFIG[:DEFAULT_CAPACITY],

--- a/lib/optimizely/helpers/sdk_settings.rb
+++ b/lib/optimizely/helpers/sdk_settings.rb
@@ -32,6 +32,7 @@ module Optimizely
       # @param odp_segment_manager - A custom odp segment manager. Required method is: `fetch_qualified_segments(user_key, user_value, options)`.
       # @param odp_event_manager - A custom odp event manager. Required method is: `send_event(type:, action:, identifiers:, data:)`
       # @param fetch_segments_timeout - The timeout in seconds of to fetch odp segments (optional. default = 10).
+      # @param odp_event_timeout - The timeout in seconds of to send odp events (optional. default = 10).
       def initialize(
         disable_odp: false,
         segments_cache_size: Constants::ODP_SEGMENTS_CACHE_CONFIG[:DEFAULT_CAPACITY],

--- a/lib/optimizely/helpers/sdk_settings.rb
+++ b/lib/optimizely/helpers/sdk_settings.rb
@@ -31,13 +31,16 @@ module Optimizely
       # @param odp_segments_cache - A custom odp segments cache. Required methods include: `save(key, value)`, `lookup(key) -> value`, and `reset()`
       # @param odp_segment_manager - A custom odp segment manager. Required method is: `fetch_qualified_segments(user_key, user_value, options)`.
       # @param odp_event_manager - A custom odp event manager. Required method is: `send_event(type:, action:, identifiers:, data:)`
+      # @param fetch_segments_timeout - The timeout in seconds of to fetch odp segments (optional. default = 10).
+      
       def initialize(
         disable_odp: false,
         segments_cache_size: Constants::ODP_SEGMENTS_CACHE_CONFIG[:DEFAULT_CAPACITY],
         segments_cache_timeout_in_secs: Constants::ODP_SEGMENTS_CACHE_CONFIG[:DEFAULT_TIMEOUT_SECONDS],
         odp_segments_cache: nil,
         odp_segment_manager: nil,
-        odp_event_manager: nil
+        odp_event_manager: nil,
+        fetch_segments_timeout: nil
       )
         @odp_disabled = disable_odp
         @segments_cache_size = segments_cache_size
@@ -45,6 +48,7 @@ module Optimizely
         @odp_segments_cache = odp_segments_cache
         @odp_segment_manager = odp_segment_manager
         @odp_event_manager = odp_event_manager
+        @fetch_segments_timeout = fetch_segments_timeout
       end
     end
   end

--- a/lib/optimizely/odp/odp_event_api_manager.rb
+++ b/lib/optimizely/odp/odp_event_api_manager.rb
@@ -22,9 +22,10 @@ module Optimizely
   class OdpEventApiManager
     # Interface that handles sending ODP events.
 
-    def initialize(logger: nil, proxy_config: nil)
+    def initialize(logger: nil, proxy_config: nil, timeout: nil)
       @logger = logger || NoOpLogger.new
       @proxy_config = proxy_config
+      @timeout = timeout || Optimizely::Helpers::Constants::ODP_REST_API_CONFIG[:REQUEST_TIMEOUT]
     end
 
     # Send events to the ODP Events API.
@@ -33,7 +34,7 @@ module Optimizely
     # @param api_host - domain url of the host
     # @param events - array of events to send
 
-    def send_odp_events(api_key, api_host, events, odp_event_timeout)
+    def send_odp_events(api_key, api_host, events)
       should_retry = false
       url = "#{api_host}/v3/events"
 
@@ -41,7 +42,7 @@ module Optimizely
 
       begin
         response = Helpers::HttpUtils.make_request(
-          url, :post, events.to_json, headers, odp_event_timeout || Optimizely::Helpers::Constants::ODP_REST_API_CONFIG[:REQUEST_TIMEOUT], @proxy_config
+          url, :post, events.to_json, headers, @timeout, @proxy_config
         )
       rescue SocketError, Timeout::Error, Errno::ECONNRESET, Errno::EHOSTUNREACH, Errno::EFAULT, Errno::ENETUNREACH, Errno::ENETDOWN, Errno::ECONNREFUSED
         log_failure('network error')

--- a/lib/optimizely/odp/odp_event_api_manager.rb
+++ b/lib/optimizely/odp/odp_event_api_manager.rb
@@ -33,7 +33,7 @@ module Optimizely
     # @param api_host - domain url of the host
     # @param events - array of events to send
 
-    def send_odp_events(api_key, api_host, events)
+    def send_odp_events(api_key, api_host, events, odp_event_timeout)
       should_retry = false
       url = "#{api_host}/v3/events"
 
@@ -41,7 +41,7 @@ module Optimizely
 
       begin
         response = Helpers::HttpUtils.make_request(
-          url, :post, events.to_json, headers, Optimizely::Helpers::Constants::ODP_REST_API_CONFIG[:REQUEST_TIMEOUT], @proxy_config
+          url, :post, events.to_json, headers, odp_event_timeout || Optimizely::Helpers::Constants::ODP_REST_API_CONFIG[:REQUEST_TIMEOUT], @proxy_config
         )
       rescue SocketError, Timeout::Error, Errno::ECONNRESET, Errno::EHOSTUNREACH, Errno::EFAULT, Errno::ENETUNREACH, Errno::ENETDOWN, Errno::ECONNREFUSED
         log_failure('network error')

--- a/lib/optimizely/odp/odp_event_manager.rb
+++ b/lib/optimizely/odp/odp_event_manager.rb
@@ -28,7 +28,7 @@ module Optimizely
     # maximum duration before the resulting LogEvent is sent to the NotificationCenter.
 
     attr_reader :batch_size, :api_manager, :logger
-    attr_accessor :odp_config, odp_event_timeout
+    attr_accessor :odp_config, :odp_event_timeout
 
     def initialize(
       api_manager: nil,

--- a/lib/optimizely/odp/odp_event_manager.rb
+++ b/lib/optimizely/odp/odp_event_manager.rb
@@ -28,7 +28,7 @@ module Optimizely
     # maximum duration before the resulting LogEvent is sent to the NotificationCenter.
 
     attr_reader :batch_size, :api_manager, :logger
-    attr_accessor :odp_config
+    attr_accessor :odp_config, odp_event_timeout
 
     def initialize(
       api_manager: nil,
@@ -233,7 +233,7 @@ module Optimizely
       i = 0
       while i < @retry_count
         begin
-          should_retry = @api_manager.send_odp_events(@api_key, @api_host, @current_batch)
+          should_retry = @api_manager.send_odp_events(@api_key, @api_host, @current_batch, @odp_event_timeout)
         rescue StandardError => e
           should_retry = false
           @logger.log(Logger::ERROR, format(Helpers::Constants::ODP_LOGS[:ODP_EVENT_FAILED], "Error: #{e.message} #{@current_batch.to_json}"))

--- a/lib/optimizely/odp/odp_event_manager.rb
+++ b/lib/optimizely/odp/odp_event_manager.rb
@@ -56,6 +56,7 @@ module Optimizely
       @current_batch = []
       @thread = nil
       @thread_exception = false
+      @odp_event_timeout = nil
     end
 
     def start!(odp_config)

--- a/lib/optimizely/odp/odp_manager.rb
+++ b/lib/optimizely/odp/odp_manager.rb
@@ -32,13 +32,14 @@ module Optimizely
     ODP_CONFIG_STATE = Helpers::Constants::ODP_CONFIG_STATE
 
     # update_odp_config must be called to complete initialization
-    def initialize(disable:, segments_cache: nil, segment_manager: nil, event_manager: nil, fetch_segments_timeout: nil, logger: nil)
+    def initialize(disable:, segments_cache: nil, segment_manager: nil, event_manager: nil, fetch_segments_timeout: nil, odp_event_timeout: nil, logger: nil)
       @enabled = !disable
       @segment_manager = segment_manager
       @event_manager = event_manager
       @logger = logger || NoOpLogger.new
       @odp_config = OdpConfig.new
       @fetch_segments_timeout = fetch_segments_timeout
+      @odp_event_timeout = odp_event_timeout
 
       unless @enabled
         @logger.log(Logger::INFO, ODP_LOGS[:ODP_NOT_ENABLED])
@@ -55,6 +56,7 @@ module Optimizely
 
       @event_manager ||= Optimizely::OdpEventManager.new(logger: @logger)
 
+      @event_manager.odp_event_timeout = odp_event_timeout
       @segment_manager.odp_config = @odp_config
     end
 
@@ -102,7 +104,7 @@ module Optimizely
       )
     end
 
-    def send_event(type:, action:, identifiers:, data:)
+    def send_event(type:, action:, identifiers:, data:, odp_event_timeout:)
       # Send an event to the ODP server.
       #
       # @param type - the event type.

--- a/lib/optimizely/odp/odp_manager.rb
+++ b/lib/optimizely/odp/odp_manager.rb
@@ -32,12 +32,13 @@ module Optimizely
     ODP_CONFIG_STATE = Helpers::Constants::ODP_CONFIG_STATE
 
     # update_odp_config must be called to complete initialization
-    def initialize(disable:, segments_cache: nil, segment_manager: nil, event_manager: nil, logger: nil)
+    def initialize(disable:, segments_cache: nil, segment_manager: nil, event_manager: nil, logger: nil, timeout: nil)
       @enabled = !disable
       @segment_manager = segment_manager
       @event_manager = event_manager
       @logger = logger || NoOpLogger.new
       @odp_config = OdpConfig.new
+      @timeout = timeout
 
       unless @enabled
         @logger.log(Logger::INFO, ODP_LOGS[:ODP_NOT_ENABLED])
@@ -75,7 +76,7 @@ module Optimizely
         return nil
       end
 
-      @segment_manager.fetch_qualified_segments(ODP_MANAGER_CONFIG[:KEY_FOR_USER_ID], user_id, options)
+      @segment_manager.fetch_qualified_segments(ODP_MANAGER_CONFIG[:KEY_FOR_USER_ID], user_id, options, timeout)
     end
 
     def identify_user(user_id:)

--- a/lib/optimizely/odp/odp_manager.rb
+++ b/lib/optimizely/odp/odp_manager.rb
@@ -38,8 +38,6 @@ module Optimizely
       @event_manager = event_manager
       @logger = logger || NoOpLogger.new
       @odp_config = OdpConfig.new
-      @fetch_segments_timeout = fetch_segments_timeout
-      @odp_event_timeout = odp_event_timeout
 
       unless @enabled
         @logger.log(Logger::INFO, ODP_LOGS[:ODP_NOT_ENABLED])
@@ -51,12 +49,11 @@ module Optimizely
           Helpers::Constants::ODP_SEGMENTS_CACHE_CONFIG[:DEFAULT_CAPACITY],
           Helpers::Constants::ODP_SEGMENTS_CACHE_CONFIG[:DEFAULT_TIMEOUT_SECONDS]
         )
-        @segment_manager = Optimizely::OdpSegmentManager.new(segments_cache, nil, @logger)
+        @segment_manager = Optimizely::OdpSegmentManager.new(segments_cache, nil, @logger, timeout: fetch_segments_timeout)
       end
 
-      @event_manager ||= Optimizely::OdpEventManager.new(logger: @logger)
+      @event_manager ||= Optimizely::OdpEventManager.new(logger: @logger, timeout: odp_event_timeout)
 
-      @event_manager.odp_event_timeout = @odp_event_timeout
       @segment_manager.odp_config = @odp_config
     end
 
@@ -78,7 +75,7 @@ module Optimizely
         return nil
       end
 
-      @segment_manager.fetch_qualified_segments(ODP_MANAGER_CONFIG[:KEY_FOR_USER_ID], user_id, options, @fetch_segments_timeout)
+      @segment_manager.fetch_qualified_segments(ODP_MANAGER_CONFIG[:KEY_FOR_USER_ID], user_id, options)
     end
 
     def identify_user(user_id:)

--- a/lib/optimizely/odp/odp_manager.rb
+++ b/lib/optimizely/odp/odp_manager.rb
@@ -32,13 +32,13 @@ module Optimizely
     ODP_CONFIG_STATE = Helpers::Constants::ODP_CONFIG_STATE
 
     # update_odp_config must be called to complete initialization
-    def initialize(disable:, segments_cache: nil, segment_manager: nil, event_manager: nil, logger: nil, timeout: nil)
+    def initialize(disable:, segments_cache: nil, segment_manager: nil, event_manager: nil, fetch_segments_timeout: nil logger: nil)
       @enabled = !disable
       @segment_manager = segment_manager
       @event_manager = event_manager
       @logger = logger || NoOpLogger.new
       @odp_config = OdpConfig.new
-      @timeout = timeout
+      @fetch_segments_timeout = fetch_segments_timeout
 
       unless @enabled
         @logger.log(Logger::INFO, ODP_LOGS[:ODP_NOT_ENABLED])
@@ -76,7 +76,7 @@ module Optimizely
         return nil
       end
 
-      @segment_manager.fetch_qualified_segments(ODP_MANAGER_CONFIG[:KEY_FOR_USER_ID], user_id, options, timeout)
+      @segment_manager.fetch_qualified_segments(ODP_MANAGER_CONFIG[:KEY_FOR_USER_ID], user_id, options, fetch_segments_timeout)
     end
 
     def identify_user(user_id:)

--- a/lib/optimizely/odp/odp_manager.rb
+++ b/lib/optimizely/odp/odp_manager.rb
@@ -56,7 +56,7 @@ module Optimizely
 
       @event_manager ||= Optimizely::OdpEventManager.new(logger: @logger)
 
-      @event_manager.odp_event_timeout = odp_event_timeout
+      @event_manager.odp_event_timeout = @odp_event_timeout
       @segment_manager.odp_config = @odp_config
     end
 

--- a/lib/optimizely/odp/odp_manager.rb
+++ b/lib/optimizely/odp/odp_manager.rb
@@ -76,7 +76,7 @@ module Optimizely
         return nil
       end
 
-      @segment_manager.fetch_qualified_segments(ODP_MANAGER_CONFIG[:KEY_FOR_USER_ID], user_id, options, fetch_segments_timeout)
+      @segment_manager.fetch_qualified_segments(ODP_MANAGER_CONFIG[:KEY_FOR_USER_ID], user_id, options, @fetch_segments_timeout)
     end
 
     def identify_user(user_id:)

--- a/lib/optimizely/odp/odp_manager.rb
+++ b/lib/optimizely/odp/odp_manager.rb
@@ -32,7 +32,7 @@ module Optimizely
     ODP_CONFIG_STATE = Helpers::Constants::ODP_CONFIG_STATE
 
     # update_odp_config must be called to complete initialization
-    def initialize(disable:, segments_cache: nil, segment_manager: nil, event_manager: nil, fetch_segments_timeout: nil logger: nil)
+    def initialize(disable:, segments_cache: nil, segment_manager: nil, event_manager: nil, fetch_segments_timeout: nil, logger: nil)
       @enabled = !disable
       @segment_manager = segment_manager
       @event_manager = event_manager

--- a/lib/optimizely/odp/odp_manager.rb
+++ b/lib/optimizely/odp/odp_manager.rb
@@ -104,7 +104,7 @@ module Optimizely
       )
     end
 
-    def send_event(type:, action:, identifiers:, data:, odp_event_timeout:)
+    def send_event(type:, action:, identifiers:, data:)
       # Send an event to the ODP server.
       #
       # @param type - the event type.

--- a/lib/optimizely/odp/odp_segment_api_manager.rb
+++ b/lib/optimizely/odp/odp_segment_api_manager.rb
@@ -22,9 +22,10 @@ module Optimizely
   class OdpSegmentApiManager
     # Interface that handles fetching audience segments.
 
-    def initialize(logger: nil, proxy_config: nil)
+    def initialize(logger: nil, proxy_config: nil, timeout: nil)
       @logger = logger || NoOpLogger.new
       @proxy_config = proxy_config
+      @timeout = timeout || Optimizely::Helpers::Constants::ODP_GRAPHQL_API_CONFIG[:REQUEST_TIMEOUT]
     end
 
     # Fetch segments from the ODP GraphQL API.
@@ -35,7 +36,7 @@ module Optimizely
     # @param user_value - value of user_key
     # @param segments_to_check - array of segments to check
 
-    def fetch_segments(api_key, api_host, user_key, user_value, segments_to_check, fetch_segments_timeout)
+    def fetch_segments(api_key, api_host, user_key, user_value, segments_to_check)
       url = "#{api_host}/v3/graphql"
 
       headers = {'Content-Type' => 'application/json', 'x-api-key' => api_key.to_s}
@@ -52,7 +53,7 @@ module Optimizely
 
       begin
         response = Helpers::HttpUtils.make_request(
-          url, :post, payload, headers, fetch_segments_timeout || Optimizely::Helpers::Constants::ODP_GRAPHQL_API_CONFIG[:REQUEST_TIMEOUT], @proxy_config
+          url, :post, payload, headers, @timeout, @proxy_config
         )
       rescue SocketError, Timeout::Error, Net::ProtocolError, Errno::ECONNRESET => e
         @logger.log(Logger::DEBUG, "GraphQL download failed: #{e}")

--- a/lib/optimizely/odp/odp_segment_api_manager.rb
+++ b/lib/optimizely/odp/odp_segment_api_manager.rb
@@ -35,7 +35,7 @@ module Optimizely
     # @param user_value - value of user_key
     # @param segments_to_check - array of segments to check
 
-    def fetch_segments(api_key, api_host, user_key, user_value, segments_to_check, timeout)
+    def fetch_segments(api_key, api_host, user_key, user_value, segments_to_check, fetch_segments_timeout)
       url = "#{api_host}/v3/graphql"
 
       headers = {'Content-Type' => 'application/json', 'x-api-key' => api_key.to_s}
@@ -52,7 +52,7 @@ module Optimizely
 
       begin
         response = Helpers::HttpUtils.make_request(
-          url, :post, payload, headers, timeout || Optimizely::Helpers::Constants::ODP_GRAPHQL_API_CONFIG[:REQUEST_TIMEOUT], @proxy_config
+          url, :post, payload, headers, fetch_segments_timeout || Optimizely::Helpers::Constants::ODP_GRAPHQL_API_CONFIG[:REQUEST_TIMEOUT], @proxy_config
         )
       rescue SocketError, Timeout::Error, Net::ProtocolError, Errno::ECONNRESET => e
         @logger.log(Logger::DEBUG, "GraphQL download failed: #{e}")

--- a/lib/optimizely/odp/odp_segment_api_manager.rb
+++ b/lib/optimizely/odp/odp_segment_api_manager.rb
@@ -35,7 +35,7 @@ module Optimizely
     # @param user_value - value of user_key
     # @param segments_to_check - array of segments to check
 
-    def fetch_segments(api_key, api_host, user_key, user_value, segments_to_check)
+    def fetch_segments(api_key, api_host, user_key, user_value, segments_to_check, timeout)
       url = "#{api_host}/v3/graphql"
 
       headers = {'Content-Type' => 'application/json', 'x-api-key' => api_key.to_s}
@@ -52,7 +52,7 @@ module Optimizely
 
       begin
         response = Helpers::HttpUtils.make_request(
-          url, :post, payload, headers, Optimizely::Helpers::Constants::ODP_GRAPHQL_API_CONFIG[:REQUEST_TIMEOUT], @proxy_config
+          url, :post, payload, headers, timeout || Optimizely::Helpers::Constants::ODP_GRAPHQL_API_CONFIG[:REQUEST_TIMEOUT], @proxy_config
         )
       rescue SocketError, Timeout::Error, Net::ProtocolError, Errno::ECONNRESET => e
         @logger.log(Logger::DEBUG, "GraphQL download failed: #{e}")

--- a/lib/optimizely/odp/odp_segment_manager.rb
+++ b/lib/optimizely/odp/odp_segment_manager.rb
@@ -39,7 +39,7 @@ module Optimizely
     # @param options - An array of OptimizelySegmentOptions used to ignore and/or reset the cache.
     #
     # @return - Array of qualified segments.
-    def fetch_qualified_segments(user_key, user_value, options)
+    def fetch_qualified_segments(user_key, user_value, options, timeout)
       odp_api_key = @odp_config&.api_key
       odp_api_host = @odp_config&.api_host
       segments_to_check = @odp_config&.segments_to_check
@@ -72,7 +72,7 @@ module Optimizely
 
       @logger.log(Logger::DEBUG, 'Making a call to ODP server.')
 
-      segments = @api_manager.fetch_segments(odp_api_key, odp_api_host, user_key, user_value, segments_to_check)
+      segments = @api_manager.fetch_segments(odp_api_key, odp_api_host, user_key, user_value, segments_to_check, timeout)
       @segments_cache.save(cache_key, segments) unless segments.nil? || ignore_cache
       segments
     end

--- a/lib/optimizely/odp/odp_segment_manager.rb
+++ b/lib/optimizely/odp/odp_segment_manager.rb
@@ -28,7 +28,7 @@ module Optimizely
     def initialize(segments_cache, api_manager = nil, logger = nil, proxy_config = nil, timeout: nil)
       @odp_config = nil
       @logger = logger || NoOpLogger.new
-      @api_manager = api_manager || OdpSegmentApiManager.new(logger: @logger, proxy_config: proxy_config, timeout:timeout)
+      @api_manager = api_manager || OdpSegmentApiManager.new(logger: @logger, proxy_config: proxy_config, timeout: timeout)
       @segments_cache = segments_cache
     end
 

--- a/lib/optimizely/odp/odp_segment_manager.rb
+++ b/lib/optimizely/odp/odp_segment_manager.rb
@@ -39,7 +39,7 @@ module Optimizely
     # @param options - An array of OptimizelySegmentOptions used to ignore and/or reset the cache.
     #
     # @return - Array of qualified segments.
-    def fetch_qualified_segments(user_key, user_value, options, timeout)
+    def fetch_qualified_segments(user_key, user_value, options, fetch_segments_timeout)
       odp_api_key = @odp_config&.api_key
       odp_api_host = @odp_config&.api_host
       segments_to_check = @odp_config&.segments_to_check
@@ -72,7 +72,7 @@ module Optimizely
 
       @logger.log(Logger::DEBUG, 'Making a call to ODP server.')
 
-      segments = @api_manager.fetch_segments(odp_api_key, odp_api_host, user_key, user_value, segments_to_check, timeout)
+      segments = @api_manager.fetch_segments(odp_api_key, odp_api_host, user_key, user_value, segments_to_check, fetch_segments_timeout)
       @segments_cache.save(cache_key, segments) unless segments.nil? || ignore_cache
       segments
     end

--- a/lib/optimizely/odp/odp_segment_manager.rb
+++ b/lib/optimizely/odp/odp_segment_manager.rb
@@ -25,10 +25,10 @@ module Optimizely
     attr_accessor :odp_config
     attr_reader :segments_cache, :api_manager, :logger
 
-    def initialize(segments_cache, api_manager = nil, logger = nil, proxy_config = nil)
+    def initialize(segments_cache, api_manager = nil, logger = nil, proxy_config = nil, timeout: nil)
       @odp_config = nil
       @logger = logger || NoOpLogger.new
-      @api_manager = api_manager || OdpSegmentApiManager.new(logger: @logger, proxy_config: proxy_config)
+      @api_manager = api_manager || OdpSegmentApiManager.new(logger: @logger, proxy_config: proxy_config, timeout:timeout)
       @segments_cache = segments_cache
     end
 
@@ -39,7 +39,7 @@ module Optimizely
     # @param options - An array of OptimizelySegmentOptions used to ignore and/or reset the cache.
     #
     # @return - Array of qualified segments.
-    def fetch_qualified_segments(user_key, user_value, options, fetch_segments_timeout)
+    def fetch_qualified_segments(user_key, user_value, options)
       odp_api_key = @odp_config&.api_key
       odp_api_host = @odp_config&.api_host
       segments_to_check = @odp_config&.segments_to_check
@@ -72,7 +72,7 @@ module Optimizely
 
       @logger.log(Logger::DEBUG, 'Making a call to ODP server.')
 
-      segments = @api_manager.fetch_segments(odp_api_key, odp_api_host, user_key, user_value, segments_to_check, fetch_segments_timeout)
+      segments = @api_manager.fetch_segments(odp_api_key, odp_api_host, user_key, user_value, segments_to_check)
       @segments_cache.save(cache_key, segments) unless segments.nil? || ignore_cache
       segments
     end

--- a/spec/odp/odp_event_api_manager_spec.rb
+++ b/spec/odp/odp_event_api_manager_spec.rb
@@ -49,7 +49,7 @@ describe Optimizely::OdpEventApiManager do
 
       api_manager = Optimizely::OdpEventApiManager.new
       expect(spy_logger).not_to receive(:log)
-      should_retry = api_manager.send_odp_events(api_key, api_host, events)
+      should_retry = api_manager.send_odp_events(api_key, api_host, events, nil)
 
       expect(should_retry).to be false
     end
@@ -59,7 +59,7 @@ describe Optimizely::OdpEventApiManager do
       api_manager = Optimizely::OdpEventApiManager.new(logger: spy_logger)
       expect(spy_logger).to receive(:log).with(Logger::ERROR, 'ODP event send failed (network error).')
 
-      should_retry = api_manager.send_odp_events(api_key, api_host, events)
+      should_retry = api_manager.send_odp_events(api_key, api_host, events, nil)
 
       expect(should_retry).to be true
     end
@@ -77,7 +77,7 @@ describe Optimizely::OdpEventApiManager do
                        '[{"event":0,"message":"missing \'type\' field"}]}}).'
       )
 
-      should_retry = api_manager.send_odp_events(api_key, api_host, events)
+      should_retry = api_manager.send_odp_events(api_key, api_host, events, nil)
 
       expect(should_retry).to be false
     end
@@ -91,7 +91,7 @@ describe Optimizely::OdpEventApiManager do
       api_manager = Optimizely::OdpEventApiManager.new(logger: spy_logger)
       expect(spy_logger).to receive(:log).with(Logger::ERROR, 'ODP event send failed (500: Internal Server Error).')
 
-      should_retry = api_manager.send_odp_events(api_key, api_host, events)
+      should_retry = api_manager.send_odp_events(api_key, api_host, events, nil)
 
       expect(should_retry).to be true
     end

--- a/spec/odp/odp_event_api_manager_spec.rb
+++ b/spec/odp/odp_event_api_manager_spec.rb
@@ -66,7 +66,7 @@ describe Optimizely::OdpEventApiManager do
         "#{api_host}/v3/events",
         :post,
         events.to_json,
-        {"Content-Type"=>"application/json", "x-api-key"=>api_key},
+        {'Content-Type' => 'application/json', 'x-api-key' => api_key},
         14,
         nil
       ).and_call_original

--- a/spec/odp/odp_event_manager_spec.rb
+++ b/spec/odp/odp_event_manager_spec.rb
@@ -181,7 +181,7 @@ describe Optimizely::OdpEventManager do
 
       event_manager.instance_variable_set('@batch_size', 2)
       batch_count = 4
-      allow(event_manager.api_manager).to receive(:send_odp_events).exactly(batch_count).times.with(api_key, api_host, odp_events).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).exactly(batch_count).times.with(api_key, api_host, odp_events, nil).and_return(false)
 
       # create events before starting processing to simulate backlog
       allow(event_manager).to receive(:running?).and_return(true)
@@ -205,7 +205,7 @@ describe Optimizely::OdpEventManager do
     it 'should flush with flush signal' do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_return(false)
       event_manager.start!(odp_config)
 
       event_manager.send_event(**events[0])
@@ -222,7 +222,7 @@ describe Optimizely::OdpEventManager do
     it 'should flush multiple times successfully' do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).exactly(4).times.with(api_key, api_host, odp_events).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).exactly(4).times.with(api_key, api_host, odp_events, nil).and_return(false)
       event_manager.start!(odp_config)
       flush_count = 4
 
@@ -246,7 +246,7 @@ describe Optimizely::OdpEventManager do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
       retry_count = event_manager.instance_variable_get('@retry_count')
-      allow(event_manager.api_manager).to receive(:send_odp_events).exactly(retry_count + 1).times.with(api_key, api_host, odp_events).and_return(true)
+      allow(event_manager.api_manager).to receive(:send_odp_events).exactly(retry_count + 1).times.with(api_key, api_host, odp_events, nil).and_return(true)
       event_manager.start!(odp_config)
 
       event_manager.send_event(**events[0])
@@ -264,7 +264,7 @@ describe Optimizely::OdpEventManager do
     it 'should retry on network failure' do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(true, true, false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_return(true, true, false)
       event_manager.start!(odp_config)
 
       event_manager.send_event(**events[0])
@@ -282,7 +282,7 @@ describe Optimizely::OdpEventManager do
     it 'should log error on send failure' do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_raise(StandardError, 'Unexpected error')
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_raise(StandardError, 'Unexpected error')
       event_manager.start!(odp_config)
 
       event_manager.send_event(**events[0])
@@ -371,7 +371,7 @@ describe Optimizely::OdpEventManager do
     it 'should flush when timeout is reached' do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_return(false)
       event_manager.instance_variable_set('@flush_interval', 0.5)
       event_manager.start!(odp_config)
 
@@ -389,7 +389,7 @@ describe Optimizely::OdpEventManager do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       odp_config = Optimizely::OdpConfig.new
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_return(false)
       event_manager.start!(odp_config)
 
       event_manager.send_event(**events[0])
@@ -446,7 +446,7 @@ describe Optimizely::OdpEventManager do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       odp_config = Optimizely::OdpConfig.new(api_key, api_host)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_return(false)
       event_manager.start!(odp_config)
 
       event_manager.instance_variable_set('@batch_size', 2)
@@ -479,7 +479,7 @@ describe Optimizely::OdpEventManager do
       event_manager.odp_config = odp_config
       event_manager.instance_variable_set('@batch_size', 3)
 
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_return(false)
       allow(event_manager).to receive(:running?).and_return(true)
       event_manager.send_event(**events[0])
       event_manager.send_event(**events[1])

--- a/spec/odp/odp_event_manager_spec.rb
+++ b/spec/odp/odp_event_manager_spec.rb
@@ -181,7 +181,7 @@ describe Optimizely::OdpEventManager do
 
       event_manager.instance_variable_set('@batch_size', 2)
       batch_count = 4
-      allow(event_manager.api_manager).to receive(:send_odp_events).exactly(batch_count).times.with(api_key, api_host, odp_events, nil).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).exactly(batch_count).times.with(api_key, api_host, odp_events).and_return(false)
 
       # create events before starting processing to simulate backlog
       allow(event_manager).to receive(:running?).and_return(true)
@@ -205,7 +205,7 @@ describe Optimizely::OdpEventManager do
     it 'should flush with flush signal' do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
       event_manager.start!(odp_config)
 
       event_manager.send_event(**events[0])
@@ -222,7 +222,7 @@ describe Optimizely::OdpEventManager do
     it 'should flush multiple times successfully' do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).exactly(4).times.with(api_key, api_host, odp_events, nil).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).exactly(4).times.with(api_key, api_host, odp_events).and_return(false)
       event_manager.start!(odp_config)
       flush_count = 4
 
@@ -246,7 +246,7 @@ describe Optimizely::OdpEventManager do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
       retry_count = event_manager.instance_variable_get('@retry_count')
-      allow(event_manager.api_manager).to receive(:send_odp_events).exactly(retry_count + 1).times.with(api_key, api_host, odp_events, nil).and_return(true)
+      allow(event_manager.api_manager).to receive(:send_odp_events).exactly(retry_count + 1).times.with(api_key, api_host, odp_events).and_return(true)
       event_manager.start!(odp_config)
 
       event_manager.send_event(**events[0])
@@ -264,7 +264,7 @@ describe Optimizely::OdpEventManager do
     it 'should retry on network failure' do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_return(true, true, false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(true, true, false)
       event_manager.start!(odp_config)
 
       event_manager.send_event(**events[0])
@@ -282,7 +282,7 @@ describe Optimizely::OdpEventManager do
     it 'should log error on send failure' do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_raise(StandardError, 'Unexpected error')
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_raise(StandardError, 'Unexpected error')
       event_manager.start!(odp_config)
 
       event_manager.send_event(**events[0])
@@ -371,7 +371,7 @@ describe Optimizely::OdpEventManager do
     it 'should flush when timeout is reached' do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
       event_manager.instance_variable_set('@flush_interval', 0.5)
       event_manager.start!(odp_config)
 
@@ -389,7 +389,7 @@ describe Optimizely::OdpEventManager do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       odp_config = Optimizely::OdpConfig.new
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
       event_manager.start!(odp_config)
 
       event_manager.send_event(**events[0])
@@ -446,7 +446,7 @@ describe Optimizely::OdpEventManager do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       odp_config = Optimizely::OdpConfig.new(api_key, api_host)
       event_manager = Optimizely::OdpEventManager.new(logger: spy_logger)
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
       event_manager.start!(odp_config)
 
       event_manager.instance_variable_set('@batch_size', 2)
@@ -479,7 +479,7 @@ describe Optimizely::OdpEventManager do
       event_manager.odp_config = odp_config
       event_manager.instance_variable_set('@batch_size', 3)
 
-      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events, nil).and_return(false)
+      allow(event_manager.api_manager).to receive(:send_odp_events).once.with(api_key, api_host, odp_events).and_return(false)
       allow(event_manager).to receive(:running?).and_return(true)
       event_manager.send_event(**events[0])
       event_manager.send_event(**events[1])

--- a/spec/odp/odp_manager_spec.rb
+++ b/spec/odp/odp_manager_spec.rb
@@ -139,12 +139,12 @@ describe Optimizely::OdpManager do
     it 'should ignore cache' do
       segments_cache = Optimizely::LRUCache.new(500, 500)
       expect(spy_logger).not_to receive(:log).with(Logger::ERROR, anything)
-      segment_manager = Optimizely::OdpSegmentManager.new(segments_cache, nil, spy_logger)
+      segment_manager = Optimizely::OdpSegmentManager.new(segments_cache, nil, spy_logger, nil)
 
       expect(segment_manager.api_manager)
         .to receive(:fetch_segments)
         .once
-        .with(api_key, api_host, user_key, user_value, segments_to_check, nil)
+        .with(api_key, api_host, user_key, user_value, segments_to_check)
         .and_return([segments_to_check[0]])
 
       manager = Optimizely::OdpManager.new(disable: false, segment_manager: segment_manager, logger: spy_logger)
@@ -167,7 +167,7 @@ describe Optimizely::OdpManager do
       expect(segment_manager.api_manager)
         .to receive(:fetch_segments)
         .once
-        .with(api_key, api_host, user_key, user_value, segments_to_check, nil)
+        .with(api_key, api_host, user_key, user_value, segments_to_check)
         .and_return([segments_to_check[0]])
 
       manager = Optimizely::OdpManager.new(disable: false, segment_manager: segment_manager, logger: spy_logger)
@@ -193,7 +193,7 @@ describe Optimizely::OdpManager do
       expect(event_manager.api_manager)
         .to receive(:send_odp_events)
         .once
-        .with(api_key, api_host, [odp_event], nil)
+        .with(api_key, api_host, [odp_event])
         .and_return(false)
 
       manager = Optimizely::OdpManager.new(disable: false, event_manager: event_manager, logger: spy_logger)
@@ -227,7 +227,7 @@ describe Optimizely::OdpManager do
       expect(event_manager.api_manager)
         .to receive(:send_odp_events)
         .once
-        .with(api_key, api_host, [event], nil)
+        .with(api_key, api_host, [event])
         .and_return(false)
 
       manager = Optimizely::OdpManager.new(disable: false, event_manager: event_manager, logger: spy_logger)

--- a/spec/odp/odp_manager_spec.rb
+++ b/spec/odp/odp_manager_spec.rb
@@ -144,7 +144,7 @@ describe Optimizely::OdpManager do
       expect(segment_manager.api_manager)
         .to receive(:fetch_segments)
         .once
-        .with(api_key, api_host, user_key, user_value, segments_to_check)
+        .with(api_key, api_host, user_key, user_value, segments_to_check, nil)
         .and_return([segments_to_check[0]])
 
       manager = Optimizely::OdpManager.new(disable: false, segment_manager: segment_manager, logger: spy_logger)
@@ -167,7 +167,7 @@ describe Optimizely::OdpManager do
       expect(segment_manager.api_manager)
         .to receive(:fetch_segments)
         .once
-        .with(api_key, api_host, user_key, user_value, segments_to_check)
+        .with(api_key, api_host, user_key, user_value, segments_to_check, nil)
         .and_return([segments_to_check[0]])
 
       manager = Optimizely::OdpManager.new(disable: false, segment_manager: segment_manager, logger: spy_logger)
@@ -193,7 +193,7 @@ describe Optimizely::OdpManager do
       expect(event_manager.api_manager)
         .to receive(:send_odp_events)
         .once
-        .with(api_key, api_host, [odp_event])
+        .with(api_key, api_host, [odp_event], nil)
         .and_return(false)
 
       manager = Optimizely::OdpManager.new(disable: false, event_manager: event_manager, logger: spy_logger)
@@ -227,7 +227,7 @@ describe Optimizely::OdpManager do
       expect(event_manager.api_manager)
         .to receive(:send_odp_events)
         .once
-        .with(api_key, api_host, [event])
+        .with(api_key, api_host, [event], nil)
         .and_return(false)
 
       manager = Optimizely::OdpManager.new(disable: false, event_manager: event_manager, logger: spy_logger)

--- a/spec/odp/odp_segment_api_manager_spec.rb
+++ b/spec/odp/odp_segment_api_manager_spec.rb
@@ -230,7 +230,25 @@ describe Optimizely::OdpSegmentApiManager do
         )
         .to_return(status: 200, body: good_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b c], nil)
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b c])
+      expect(segments).to match_array %w[a b]
+    end
+
+    it 'should send timeout for fetch segments with custom timeout' do
+      api_manager_with_timeout = Optimizely::OdpSegmentApiManager.new(logger: spy_logger, timeout: 14)
+      stub_request(:post, "#{api_host}/v3/graphql")
+        .with(
+          headers: {'content-type': 'application/json', 'x-api-key': api_key},
+          body: {query: graphql_query, variables: {userId: user_value, audiences: %w[a b c]}}
+        )
+        .to_return(status: 200, body: good_response_data.to_json)
+      expect(Optimizely::Helpers::HttpUtils).to receive(:make_request).with(anything,
+                                                                            anything,
+                                                                            anything,
+                                                                            anything,
+                                                                            14,
+                                                                            nil).and_call_original
+      segments = api_manager_with_timeout.fetch_segments(api_key, api_host, user_key, user_value, %w[a b c])
       expect(segments).to match_array %w[a b]
     end
 
@@ -238,7 +256,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: good_empty_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, [], nil)
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, [])
       expect(segments).to match_array []
     end
 
@@ -246,7 +264,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: node_missing_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -259,7 +277,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: mixed_missing_keys_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -272,7 +290,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: invalid_identifier_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -285,7 +303,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: other_exception_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -298,7 +316,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: bad_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -311,7 +329,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: name_invalid_response_data)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -324,7 +342,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: invalid_edges_key_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -337,7 +355,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: invalid_key_for_error_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -350,7 +368,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .and_raise(SocketError)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -368,7 +386,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 400)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -381,7 +399,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 500)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -393,19 +411,19 @@ describe Optimizely::OdpSegmentApiManager do
     it 'should create correct subset filter' do
       stub_request(:post, "#{api_host}/v3/graphql")
         .with(body: {query: graphql_query, variables: {userId: user_value, audiences: []}})
-      api_manager.fetch_segments(api_key, api_host, user_key, user_value, nil, nil)
+      api_manager.fetch_segments(api_key, api_host, user_key, user_value, nil)
 
       stub_request(:post, "#{api_host}/v3/graphql")
         .with(body: {query: graphql_query, variables: {userId: user_value, audiences: []}})
-      api_manager.fetch_segments(api_key, api_host, user_key, user_value, [], nil)
+      api_manager.fetch_segments(api_key, api_host, user_key, user_value, [])
 
       stub_request(:post, "#{api_host}/v3/graphql")
         .with(body: {query: graphql_query, variables: {userId: user_value, audiences: %w[a]}})
-      api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a], nil)
+      api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a])
 
       stub_request(:post, "#{api_host}/v3/graphql")
         .with(body: {query: graphql_query, variables: {userId: user_value, audiences: %w[a b c]}})
-      api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b c], nil)
+      api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b c])
     end
 
     it 'should pass the proxy config that is passed in' do
@@ -413,7 +431,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
 
       api_manager = Optimizely::OdpSegmentApiManager.new(logger: spy_logger, proxy_config: :proxy_config)
-      api_manager.fetch_segments(api_key, api_host, user_key, user_value, [], nil)
+      api_manager.fetch_segments(api_key, api_host, user_key, user_value, [])
       expect(Optimizely::Helpers::HttpUtils).to have_received(:make_request).with(anything, anything, anything, anything, anything, :proxy_config)
     end
   end

--- a/spec/odp/odp_segment_api_manager_spec.rb
+++ b/spec/odp/odp_segment_api_manager_spec.rb
@@ -230,7 +230,7 @@ describe Optimizely::OdpSegmentApiManager do
         )
         .to_return(status: 200, body: good_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b c])
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b c], nil)
       expect(segments).to match_array %w[a b]
     end
 
@@ -238,7 +238,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: good_empty_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, [])
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, [], nil)
       expect(segments).to match_array []
     end
 
@@ -246,7 +246,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: node_missing_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -259,7 +259,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: mixed_missing_keys_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -272,7 +272,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: invalid_identifier_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -285,7 +285,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: other_exception_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -298,7 +298,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: bad_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -311,7 +311,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: name_invalid_response_data)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -324,7 +324,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: invalid_edges_key_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -337,7 +337,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 200, body: invalid_key_for_error_response_data.to_json)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -350,7 +350,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .and_raise(SocketError)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -368,7 +368,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 400)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -381,7 +381,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
         .to_return(status: 500)
 
-      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b])
+      segments = api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b], nil)
       expect(segments).to be_nil
 
       expect(spy_logger).to have_received(:log).once.with(
@@ -393,19 +393,19 @@ describe Optimizely::OdpSegmentApiManager do
     it 'should create correct subset filter' do
       stub_request(:post, "#{api_host}/v3/graphql")
         .with(body: {query: graphql_query, variables: {userId: user_value, audiences: []}})
-      api_manager.fetch_segments(api_key, api_host, user_key, user_value, nil)
+      api_manager.fetch_segments(api_key, api_host, user_key, user_value, nil, nil)
 
       stub_request(:post, "#{api_host}/v3/graphql")
         .with(body: {query: graphql_query, variables: {userId: user_value, audiences: []}})
-      api_manager.fetch_segments(api_key, api_host, user_key, user_value, [])
+      api_manager.fetch_segments(api_key, api_host, user_key, user_value, [], nil)
 
       stub_request(:post, "#{api_host}/v3/graphql")
         .with(body: {query: graphql_query, variables: {userId: user_value, audiences: %w[a]}})
-      api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a])
+      api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a], nil)
 
       stub_request(:post, "#{api_host}/v3/graphql")
         .with(body: {query: graphql_query, variables: {userId: user_value, audiences: %w[a b c]}})
-      api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b c])
+      api_manager.fetch_segments(api_key, api_host, user_key, user_value, %w[a b c], nil)
     end
 
     it 'should pass the proxy config that is passed in' do
@@ -413,7 +413,7 @@ describe Optimizely::OdpSegmentApiManager do
       stub_request(:post, "#{api_host}/v3/graphql")
 
       api_manager = Optimizely::OdpSegmentApiManager.new(logger: spy_logger, proxy_config: :proxy_config)
-      api_manager.fetch_segments(api_key, api_host, user_key, user_value, [])
+      api_manager.fetch_segments(api_key, api_host, user_key, user_value, [], nil)
       expect(Optimizely::Helpers::HttpUtils).to have_received(:make_request).with(anything, anything, anything, anything, anything, :proxy_config)
     end
   end

--- a/spec/odp/odp_segment_manager_spec.rb
+++ b/spec/odp/odp_segment_manager_spec.rb
@@ -92,7 +92,7 @@ describe Optimizely::OdpSegmentManager do
       segment_manager = Optimizely::OdpSegmentManager.new(segments_cache, nil, spy_logger)
       segment_manager.odp_config = Optimizely::OdpConfig.new(api_key, api_host, segments_to_check)
 
-      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [])
+      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [], nil)
 
       expect(segments).to match_array(%w[a b])
       expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
@@ -105,7 +105,7 @@ describe Optimizely::OdpSegmentManager do
       segment_manager = Optimizely::OdpSegmentManager.new(segments_cache, nil, spy_logger)
       segment_manager.odp_config = Optimizely::OdpConfig.new(api_key, api_host, [])
 
-      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [])
+      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [], nil)
 
       expect(segments).to match_array([])
       expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
@@ -121,7 +121,7 @@ describe Optimizely::OdpSegmentManager do
       cache_key = segment_manager.send(:make_cache_key, user_key, '123')
       segment_manager.segments_cache.save(cache_key, %w[d])
 
-      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [])
+      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [], nil)
 
       expect(segments).to match_array(%w[a b])
       actual_cache_key = segment_manager.send(:make_cache_key, user_key, user_value)
@@ -136,7 +136,7 @@ describe Optimizely::OdpSegmentManager do
       cache_key = segment_manager.send(:make_cache_key, user_key, user_value)
       segment_manager.segments_cache.save(cache_key, %w[c])
 
-      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [])
+      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [], nil)
 
       expect(segments).to match_array(%w[c])
       expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
@@ -146,7 +146,7 @@ describe Optimizely::OdpSegmentManager do
       segment_manager = Optimizely::OdpSegmentManager.new(segments_cache, nil, spy_logger)
       segment_manager.odp_config = Optimizely::OdpConfig.new
 
-      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [])
+      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [], nil)
 
       expect(segments).to be_nil
       expect(spy_logger).to have_received(:log).with(Logger::ERROR, 'Audience segments fetch failed (ODP is not enabled).')
@@ -159,7 +159,7 @@ describe Optimizely::OdpSegmentManager do
       segment_manager = Optimizely::OdpSegmentManager.new(segments_cache, nil, spy_logger)
       segment_manager.odp_config = Optimizely::OdpConfig.new(api_key, api_host, segments_to_check)
 
-      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [])
+      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [], nil)
 
       expect(segments).to be_nil
       expect(spy_logger).to have_received(:log).with(Logger::ERROR, 'Audience segments fetch failed (500).')
@@ -175,7 +175,7 @@ describe Optimizely::OdpSegmentManager do
       cache_key = segment_manager.send(:make_cache_key, user_key, user_value)
       segment_manager.segments_cache.save(cache_key, %w[d])
 
-      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [Optimizely::OptimizelySegmentOption::IGNORE_CACHE])
+      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [Optimizely::OptimizelySegmentOption::IGNORE_CACHE], nil)
 
       expect(segments).to match_array(%w[a b])
       expect(segment_manager.segments_cache.lookup(cache_key)).to match_array(%w[d])
@@ -193,7 +193,7 @@ describe Optimizely::OdpSegmentManager do
       segment_manager.segments_cache.save(cache_key, %w[d])
       segment_manager.segments_cache.save('123', %w[c d])
 
-      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [Optimizely::OptimizelySegmentOption::RESET_CACHE])
+      segments = segment_manager.fetch_qualified_segments(user_key, user_value, [Optimizely::OptimizelySegmentOption::RESET_CACHE], nil)
 
       expect(segments).to match_array(%w[a b])
       expect(segment_manager.segments_cache.lookup(cache_key)).to match_array(%w[a b])
@@ -210,7 +210,7 @@ describe Optimizely::OdpSegmentManager do
     it 'should log error if odp_config not set' do
       segment_manager = Optimizely::OdpSegmentManager.new(segments_cache, nil, spy_logger)
 
-      response = segment_manager.fetch_qualified_segments(user_key, user_value, [])
+      response = segment_manager.fetch_qualified_segments(user_key, user_value, [], nil)
       expect(response).to be_nil
       expect(spy_logger).to have_received(:log).with(Logger::ERROR, 'Audience segments fetch failed (ODP is not enabled).')
     end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -4533,7 +4533,7 @@ describe 'Optimizely' do
         end
 
         def reset; end
-        def fetch_qualified_segments(user_key, user_value, options, fetch_segments_timeout); end
+        def fetch_qualified_segments(user_key, user_value, options); end
       end
 
       stub_request(:get, 'https://cdn.optimizely.com/datafiles/sdk-key.json')

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -4533,7 +4533,7 @@ describe 'Optimizely' do
         end
 
         def reset; end
-        def fetch_qualified_segments(user_key, user_value, options); end
+        def fetch_qualified_segments(user_key, user_value, options, fetch_segments_timeout); end
       end
 
       stub_request(:get, 'https://cdn.optimizely.com/datafiles/sdk-key.json')
@@ -4566,6 +4566,7 @@ describe 'Optimizely' do
 
     it 'should accept valid custom event manager' do
       class CustomEventManager # rubocop:disable Lint/ConstantDefinitionInBlock
+        attr_accessor :odp_event_timeout
         def send_event(extra_param = nil, action:, type:, identifiers:, data:, other_extra_param: 'great'); end
         def start!(odp_config); end
         def update_config; end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -4567,6 +4567,7 @@ describe 'Optimizely' do
     it 'should accept valid custom event manager' do
       class CustomEventManager # rubocop:disable Lint/ConstantDefinitionInBlock
         attr_accessor :odp_event_timeout
+
         def send_event(extra_param = nil, action:, type:, identifiers:, data:, other_extra_param: 'great'); end
         def start!(odp_config); end
         def update_config; end


### PR DESCRIPTION
## Summary
- Fetch segment and send opd event timeout made configurable through `sdk_settings` option


## Test plan
- All unit tests and FSC should pass.

## Ticket Number
FSSDK-8692
