### PR TITLE
feat: add notification center registry

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -1188,6 +1188,7 @@ module Optimizely
         @sdk_settings.odp_segments_cache = nil
       end
 
+      # no need to instantiate a cache if a custom cache or segment manager is provided.
       if !@sdk_settings.odp_disabled && @sdk_settings.odp_segment_manager.nil?
         @sdk_settings.odp_segments_cache ||= LRUCache.new(
           @sdk_settings.segments_cache_size,

--- a/lib/optimizely/config_manager/project_config_manager.rb
+++ b/lib/optimizely/config_manager/project_config_manager.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2019, Optimizely and contributors
+#    Copyright 2019, 2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -20,5 +20,6 @@ module Optimizely
     # Interface for fetching ProjectConfig instance.
 
     def config; end
+    def sdk_key; end
   end
 end

--- a/lib/optimizely/config_manager/static_project_config_manager.rb
+++ b/lib/optimizely/config_manager/static_project_config_manager.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2019-2020, 2022, Optimizely and contributors
+#    Copyright 2019-2020, 2022-2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ require_relative 'project_config_manager'
 module Optimizely
   class StaticProjectConfigManager < ProjectConfigManager
     # Implementation of ProjectConfigManager interface.
-    attr_reader :config
+    attr_reader :config, :sdk_key
 
     def initialize(datafile, logger, error_handler, skip_json_validation)
       # Looks up and sets datafile and config based on response body.
@@ -41,6 +41,7 @@ module Optimizely
         error_handler,
         skip_json_validation
       )
+      @sdk_key = @config&.sdk_key
       @optimizely_config = nil
     end
 

--- a/lib/optimizely/exceptions.rb
+++ b/lib/optimizely/exceptions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2020, 2022, Optimizely and contributors
+#    Copyright 2016-2020, 2022-2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -28,6 +28,13 @@ module Optimizely
   class HTTPUriError < Error
     # Raised when a provided URI is invalid.
     def initialize(msg = 'Provided URI was invalid.')
+      super
+    end
+  end
+
+  class MissingSdkKeyError < Error
+    # Raised when a provided URI is invalid.
+    def initialize(msg = 'SDK key not provided/cannot be found in the datafile.')
       super
     end
   end

--- a/lib/optimizely/notification_center_registry.rb
+++ b/lib/optimizely/notification_center_registry.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+#
+#    Copyright 2023, Optimizely and contributors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+require_relative 'notification_center'
+require_relative 'exceptions'
+
+module Optimizely
+  class NotificationCenterRegistry
+    private_class_method :new
+    # Class managing internal notification centers.
+    # @api no-doc
+    @notification_centers = {}
+    @mutex = Mutex.new
+
+    # Returns an internal notification center for the given sdk_key, creating one
+    # if none exists yet.
+    #
+    # Args:
+    # sdk_key: A string sdk key to uniquely identify the notification center.
+    # logger: Optional logger.
+
+    # Returns:
+    # nil or NotificationCenter
+    def self.get_notification_center(sdk_key, logger)
+      unless sdk_key
+        logger&.log(Logger::ERROR, "#{MissingSdkKeyError.new.message} ODP may not work properly without it.")
+        return nil
+      end
+
+      notification_center = nil
+
+      @mutex.synchronize do
+        if @notification_centers.key?(sdk_key)
+          notification_center = @notification_centers[sdk_key]
+        else
+          notification_center = NotificationCenter.new(logger, nil)
+          @notification_centers[sdk_key] = notification_center
+        end
+      end
+
+      notification_center
+    end
+
+    # Remove a previously added notification center and clear all its listeners.
+
+    # Args:
+    # sdk_key: The sdk_key of the notification center to remove.
+    def self.remove_notification_center(sdk_key)
+      @mutex.synchronize do
+        @notification_centers
+          .delete(sdk_key)
+          &.clear_all_notification_listeners
+      end
+      nil
+    end
+  end
+end

--- a/spec/config_manager/http_project_config_manager_spec.rb
+++ b/spec/config_manager/http_project_config_manager_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2019-2020, 2022, Optimizely and contributors
+#    Copyright 2019-2020, 2022-2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ describe Optimizely::HTTPProjectConfigManager do
   describe '.project_config_manager' do
     it 'should get project config when valid url is given' do
       @http_project_config_manager = Optimizely::HTTPProjectConfigManager.new(
+        sdk_key: 'valid_sdk_key',
         url: 'https://cdn.optimizely.com/datafiles/valid_sdk_key.json'
       )
 
@@ -75,6 +76,7 @@ describe Optimizely::HTTPProjectConfigManager do
         .to_return(status: 200, body: VALID_SDK_KEY_CONFIG_JSON, headers: {})
 
       @http_project_config_manager = Optimizely::HTTPProjectConfigManager.new(
+        sdk_key: 'valid_sdk_key',
         url: 'http://cdn.optimizely.com/datafiles/valid_sdk_key.json'
       )
 

--- a/spec/notification_center_registry_spec.rb
+++ b/spec/notification_center_registry_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+#
+#    Copyright 2017-2019, 2022-2023, Optimizely and contributors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+require 'spec_helper'
+require 'optimizely/error_handler'
+require 'optimizely/event_builder'
+require 'optimizely/exceptions'
+require 'optimizely/logger'
+require 'optimizely/notification_center'
+require 'optimizely/notification_center_registry'
+describe Optimizely::NotificationCenter do
+  let(:spy_logger) { spy('logger') }
+  let(:config_body) { OptimizelySpec::VALID_CONFIG_BODY }
+  let(:config_body_JSON) { OptimizelySpec::VALID_CONFIG_BODY_JSON }
+  let(:error_handler) { Optimizely::NoOpErrorHandler.new }
+  let(:logger) { Optimizely::NoOpLogger.new }
+  let(:notification_center) { Optimizely::NotificationCenter.new(spy_logger, error_handler) }
+
+  describe '#NotificationCenterRegistry' do
+    describe 'test get notification center' do
+      it 'should log error with no sdk_key' do
+        Optimizely::NotificationCenterRegistry.get_notification_center(nil, spy_logger)
+        expect(spy_logger).to have_received(:log).with(Logger::ERROR, "#{Optimizely::MissingSdkKeyError.new.message} ODP may not work properly without it.")
+      end
+
+      it 'should return notification center with odp callback' do
+        sdk_key = 'VALID'
+        stub_request(:get, "https://cdn.optimizely.com/datafiles/#{sdk_key}.json")
+          .to_return(status: 200, body: config_body_JSON)
+
+        project = Optimizely::Project.new(nil, nil, spy_logger, nil, false, nil, sdk_key)
+
+        notification_center = Optimizely::NotificationCenterRegistry.get_notification_center(sdk_key, spy_logger)
+        expect(notification_center).to be_a Optimizely::NotificationCenter
+
+        config_notifications = notification_center.instance_variable_get('@notifications')[Optimizely::NotificationCenter::NOTIFICATION_TYPES[:OPTIMIZELY_CONFIG_UPDATE]]
+        expect(config_notifications).to include({notification_id: anything, callback: project.method(:update_odp_config_on_datafile_update)})
+        expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+
+        project.close
+      end
+
+      it 'should only create one notification center per sdk_key' do
+        sdk_key = 'single'
+        stub_request(:get, "https://cdn.optimizely.com/datafiles/#{sdk_key}.json")
+          .to_return(status: 200, body: config_body_JSON)
+
+        notification_center = Optimizely::NotificationCenterRegistry.get_notification_center(sdk_key, spy_logger)
+        project = Optimizely::Project.new(nil, nil, spy_logger, nil, false, nil, sdk_key)
+
+        expect(notification_center).to eq(Optimizely::NotificationCenterRegistry.get_notification_center(sdk_key, spy_logger))
+        expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+
+        project.close
+      end
+    end
+
+    describe 'test remove notification center' do
+      it 'should remove notification center and callbacks' do
+        sdk_key = 'segments-test'
+        stub_request(:get, "https://cdn.optimizely.com/datafiles/#{sdk_key}.json")
+          .to_return(status: 200, body: config_body_JSON)
+
+        notification_center = Optimizely::NotificationCenterRegistry.get_notification_center(sdk_key, spy_logger)
+        expect(notification_center).to receive(:send_notifications).once
+
+        project = Optimizely::Project.new(nil, nil, spy_logger, nil, false, nil, sdk_key)
+        project.config_manager.config
+
+        Optimizely::NotificationCenterRegistry.remove_notification_center(sdk_key)
+        expect(Optimizely::NotificationCenterRegistry.instance_variable_get('@notification_centers').values).not_to include(notification_center)
+
+        revised_datafile = config_body.dup
+        revised_datafile['revision'] = (revised_datafile['revision'].to_i + 1).to_s
+        revised_datafile = Optimizely::DatafileProjectConfig.create(JSON.dump(revised_datafile), spy_logger, nil, nil)
+
+        # trigger notification
+        project.config_manager.send(:set_config, revised_datafile)
+        expect(notification_center).not_to receive(:send_notifications)
+        expect(notification_center).not_to eq(Optimizely::NotificationCenterRegistry.get_notification_center(sdk_key, spy_logger))
+
+        expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+
+        project.close
+      end
+    end
+  end
+end

--- a/spec/notification_center_spec.rb
+++ b/spec/notification_center_spec.rb
@@ -313,7 +313,7 @@ describe Optimizely::NotificationCenter do
         notification_type = Optimizely::NotificationCenter::NOTIFICATION_TYPES[:ACTIVATE]
         @inner_notification_center.clear_notification_listeners(notification_type)
         expect { @inner_notification_center.clear_notification_listeners(notification_type) }
-          .to_not raise_error(Optimizely::InvalidNotificationType)
+          .to_not raise_error
         expect(
           @inner_notification_center.notifications[
             Optimizely::NotificationCenter::NOTIFICATION_TYPES[:ACTIVATE]

--- a/spec/optimizely_factory_spec.rb
+++ b/spec/optimizely_factory_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2019, 2022, Optimizely and contributors
+#    Copyright 2019, 2022-2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ describe Optimizely::OptimizelyFactory do
   describe '.default_instance_with_manager' do
     it 'should take provided custom config manager' do
       class CustomConfigManager # rubocop:disable Lint/ConstantDefinitionInBlock
-        attr_reader :config
+        attr_reader :config, :sdk_key
       end
 
       custom_config_manager = CustomConfigManager.new

--- a/spec/optimizely_user_context_spec.rb
+++ b/spec/optimizely_user_context_spec.rb
@@ -382,7 +382,7 @@ describe 'Optimizely' do
         expect(decision.user_context.forced_decisions).to eq(context => forced_decision)
         expect(decision.reasons).to eq(['Variation (3324490633) is mapped to flag (feature_1), rule (exp_with_audience) and user (tester) in the forced decision map.'])
       end
-      expected.to raise_error
+      expected.to raise_error Optimizely::InvalidVariationError
     end
 
     it 'should return correct variation if rule in forced decision is deleted' do

--- a/spec/spec_params.rb
+++ b/spec/spec_params.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2021, Optimizely and contributors
+#    Copyright 2016-2021, 2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -1328,7 +1328,8 @@ module OptimizelySpec
         'key' => 'event1'
       }
     ],
-    'revision' => '101'
+    'revision' => '101',
+    'sdkKey' => 'INTEGRATIONS'
   }.freeze
 
   SIMILAR_EXP_KEYS = {
@@ -1936,4 +1937,21 @@ module OptimizelySpec
   # SEND_FLAG_DECISIONS_DISABLED_CONFIG['sendFlagDecisions'] = false
 
   CONFIG_DICT_WITH_INTEGRATIONS_JSON = JSON.dump(CONFIG_DICT_WITH_INTEGRATIONS)
+
+  def self.deep_clone(obj)
+    obj.dup.tap do |new_obj|
+      case new_obj
+      when Hash
+        new_obj.each do |key, val|
+          new_obj[key] = deep_clone(val)
+        end
+      when Array
+        new_obj.map! do |val|
+          deep_clone(val)
+        end
+      else
+        new_obj
+      end
+    end
+  end
 end


### PR DESCRIPTION
Summary
-------
Create a private registry of NotificationCenters for internal use.
- Remove dependence on user supplied NotificationCenter.
- Resolve issue of notifications being registered with one NotificationCenter and sent to a different one.

Test plan
---------
added tests to
- notification_center_registry_spec.rb
- project_spec.rb
- http_project_config_manager_spec.rb
- optimizely_factory_spec.rb

Ticket
------

[FSSDK-8775](https://jira.sso.episerver.net/browse/FSSDK-8775)
