### PR TITLE
feat: add odp flush interval to sdk_settings

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -1203,6 +1203,7 @@ module Optimizely
         segments_cache: @sdk_settings.odp_segments_cache,
         fetch_segments_timeout: @sdk_settings.fetch_segments_timeout,
         odp_event_timeout: @sdk_settings.odp_event_timeout,
+        odp_flush_interval: @sdk_settings.odp_flush_interval,
         logger: @logger
       )
 

--- a/lib/optimizely/helpers/sdk_settings.rb
+++ b/lib/optimizely/helpers/sdk_settings.rb
@@ -21,7 +21,8 @@ require_relative 'constants'
 module Optimizely
   module Helpers
     class OptimizelySdkSettings
-      attr_accessor :odp_disabled, :segments_cache_size, :segments_cache_timeout_in_secs, :odp_segments_cache, :odp_segment_manager, :odp_event_manager, :fetch_segments_timeout, :odp_event_timeout
+      attr_accessor :odp_disabled, :segments_cache_size, :segments_cache_timeout_in_secs, :odp_segments_cache, :odp_segment_manager,
+                    :odp_event_manager, :fetch_segments_timeout, :odp_event_timeout, :odp_flush_interval
 
       # Contains configuration used for Optimizely Project initialization.
       #
@@ -31,8 +32,9 @@ module Optimizely
       # @param odp_segments_cache - A custom odp segments cache. Required methods include: `save(key, value)`, `lookup(key) -> value`, and `reset()`
       # @param odp_segment_manager - A custom odp segment manager. Required method is: `fetch_qualified_segments(user_key, user_value, options)`.
       # @param odp_event_manager - A custom odp event manager. Required method is: `send_event(type:, action:, identifiers:, data:)`
-      # @param fetch_segments_timeout - The timeout in seconds of to fetch odp segments (optional. default = 10).
-      # @param odp_event_timeout - The timeout in seconds of to send odp events (optional. default = 10).
+      # @param odp_segment_request_timeout - Time to wait in seconds for fetch_qualified_segments (optional. default = 10).
+      # @param odp_event_request_timeout - Time to wait in seconds for send_odp_events (optional. default = 10).
+      # @param odp_event_flush_interval - Time to wait in seconds for odp events to accumulate before sending (optional. default = 1).
       def initialize(
         disable_odp: false,
         segments_cache_size: Constants::ODP_SEGMENTS_CACHE_CONFIG[:DEFAULT_CAPACITY],
@@ -40,8 +42,9 @@ module Optimizely
         odp_segments_cache: nil,
         odp_segment_manager: nil,
         odp_event_manager: nil,
-        fetch_segments_timeout: nil,
-        odp_event_timeout: nil
+        odp_segment_request_timeout: nil,
+        odp_event_request_timeout: nil,
+        odp_event_flush_interval: nil
       )
         @odp_disabled = disable_odp
         @segments_cache_size = segments_cache_size
@@ -49,8 +52,9 @@ module Optimizely
         @odp_segments_cache = odp_segments_cache
         @odp_segment_manager = odp_segment_manager
         @odp_event_manager = odp_event_manager
-        @fetch_segments_timeout = fetch_segments_timeout
-        @odp_event_timeout = odp_event_timeout
+        @fetch_segments_timeout = odp_segment_request_timeout
+        @odp_event_timeout = odp_event_request_timeout
+        @odp_flush_interval = odp_event_flush_interval
       end
     end
   end

--- a/lib/optimizely/odp/odp_event_manager.rb
+++ b/lib/optimizely/odp/odp_event_manager.rb
@@ -34,7 +34,8 @@ module Optimizely
       api_manager: nil,
       logger: NoOpLogger.new,
       proxy_config: nil,
-      timeout: nil
+      request_timeout: nil,
+      flush_interval: nil
     )
       super()
 
@@ -48,9 +49,9 @@ module Optimizely
       # received signal should be sent after adding item to event_queue
       @received = ConditionVariable.new
       @logger = logger
-      @api_manager = api_manager || OdpEventApiManager.new(logger: @logger, proxy_config: proxy_config, timeout: timeout)
-      @batch_size = Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_BATCH_SIZE]
-      @flush_interval = Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_FLUSH_INTERVAL_SECONDS]
+      @api_manager = api_manager || OdpEventApiManager.new(logger: @logger, proxy_config: proxy_config, timeout: request_timeout)
+      @flush_interval = flush_interval || Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_FLUSH_INTERVAL_SECONDS]
+      @batch_size = @flush_interval&.zero? ? 0 : Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_BATCH_SIZE]
       @flush_deadline = 0
       @retry_count = Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_RETRY_COUNT]
       # current_batch should only be accessed by processing thread

--- a/lib/optimizely/odp/odp_event_manager.rb
+++ b/lib/optimizely/odp/odp_event_manager.rb
@@ -51,7 +51,7 @@ module Optimizely
       @logger = logger
       @api_manager = api_manager || OdpEventApiManager.new(logger: @logger, proxy_config: proxy_config, timeout: request_timeout)
       @flush_interval = flush_interval || Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_FLUSH_INTERVAL_SECONDS]
-      @batch_size = @flush_interval&.zero? ? 0 : Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_BATCH_SIZE]
+      @batch_size = @flush_interval&.zero? ? 1 : Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_BATCH_SIZE]
       @flush_deadline = 0
       @retry_count = Helpers::Constants::ODP_EVENT_MANAGER[:DEFAULT_RETRY_COUNT]
       # current_batch should only be accessed by processing thread

--- a/lib/optimizely/odp/odp_manager.rb
+++ b/lib/optimizely/odp/odp_manager.rb
@@ -32,7 +32,16 @@ module Optimizely
     ODP_CONFIG_STATE = Helpers::Constants::ODP_CONFIG_STATE
 
     # update_odp_config must be called to complete initialization
-    def initialize(disable:, segments_cache: nil, segment_manager: nil, event_manager: nil, fetch_segments_timeout: nil, odp_event_timeout: nil, logger: nil)
+    def initialize(
+      disable:,
+      segments_cache: nil,
+      segment_manager: nil,
+      event_manager: nil,
+      fetch_segments_timeout: nil,
+      odp_event_timeout: nil,
+      odp_flush_interval: nil,
+      logger: nil
+    )
       @enabled = !disable
       @segment_manager = segment_manager
       @event_manager = event_manager
@@ -52,7 +61,7 @@ module Optimizely
         @segment_manager = Optimizely::OdpSegmentManager.new(segments_cache, nil, @logger, timeout: fetch_segments_timeout)
       end
 
-      @event_manager ||= Optimizely::OdpEventManager.new(logger: @logger, timeout: odp_event_timeout)
+      @event_manager ||= Optimizely::OdpEventManager.new(logger: @logger, request_timeout: odp_event_timeout, flush_interval: odp_flush_interval)
 
       @segment_manager.odp_config = @odp_config
     end


### PR DESCRIPTION
## Summary
Added odp_event_flush_interval to OptimizelySdkSetting to pass into the OdpEventManager. The value in seconds determines when to flush queued ODP events.

## Test plan
Updated:
project_spec.rb
odp_event_manager_spec.rb


## Ticket
- [FSSDK-8803](https://jira.sso.episerver.net/browse/FSSDK-8803)
