### PR TITLE
[FSSDK-7825] fix errant test logging

### DIFF
--- a/lib/optimizely/config/datafile_project_config.rb
+++ b/lib/optimizely/config/datafile_project_config.rb
@@ -184,20 +184,19 @@ module Optimizely
       # skip_json_validation - Optional boolean param which allows skipping JSON schema
       #                       validation upon object invocation. By default JSON schema validation will be performed.
       # Returns instance of DatafileProjectConfig, nil otherwise.
+      logger ||= SimpleLogger.new
       if !skip_json_validation && !Helpers::Validator.datafile_valid?(datafile)
-        default_logger = SimpleLogger.new
-        default_logger.log(Logger::ERROR, InvalidInputError.new('datafile').message)
+        logger.log(Logger::ERROR, InvalidInputError.new('datafile').message)
         return nil
       end
 
       begin
         config = new(datafile, logger, error_handler)
       rescue StandardError => e
-        default_logger = SimpleLogger.new
         error_to_handle = e.instance_of?(InvalidDatafileVersionError) ? e : InvalidInputError.new('datafile')
         error_msg = error_to_handle.message
 
-        default_logger.log(Logger::ERROR, error_msg)
+        logger.log(Logger::ERROR, error_msg)
         error_handler.handle_error error_to_handle
         return nil
       end

--- a/spec/event_builder_spec.rb
+++ b/spec/event_builder_spec.rb
@@ -27,10 +27,10 @@ describe Optimizely::EventBuilder do
     @config_body = OptimizelySpec::VALID_CONFIG_BODY
     @config_body_json = OptimizelySpec::VALID_CONFIG_BODY_JSON
     @error_handler = Optimizely::NoOpErrorHandler.new
-    @logger = Optimizely::SimpleLogger.new
   end
 
   before(:example) do
+    @logger = spy('logger')
     config = Optimizely::DatafileProjectConfig.new(@config_body_json, @logger, @error_handler)
     @event_builder = Optimizely::EventBuilder.new(@logger)
     @event = config.get_event_from_key('test_event')

--- a/spec/notification_center_registry_spec.rb
+++ b/spec/notification_center_registry_spec.rb
@@ -38,7 +38,7 @@ describe Optimizely::NotificationCenter do
       end
 
       it 'should return notification center with odp callback' do
-        sdk_key = 'VALID'
+        sdk_key = 'VALID_KEY'
         stub_request(:get, "https://cdn.optimizely.com/datafiles/#{sdk_key}.json")
           .to_return(status: 200, body: config_body_JSON)
 


### PR DESCRIPTION
## Summary
Changed `DatafileProjectConfig.create` to use the provided logger in case of error.
- Existing functionality assumed there was no valid logger. This method is always called after logger has been validated.
- If the user has provided a logger, the expectation is that the logger will be used for all logging.

## Test plan
all tests pass

## Ticket
[FSSDK-7825](https://jira.sso.episerver.net/browse/FSSDK-7825)