### PR TITLE
[FSSDK-9074] fix: odp event validation

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -895,7 +895,7 @@ module Optimizely
 
     # Send an event to the ODP server.
     #
-    # @param action - the event action name.
+    # @param action - the event action name. Cannot be nil or empty string.
     # @param identifiers - a hash for identifiers. The caller must provide at least one key-value pair.
     # @param type - the event type (default = "fullstack").
     # @param data - a hash for associated data. The default event data will be added to this data before sending to the ODP server.
@@ -910,6 +910,13 @@ module Optimizely
         @logger.log(Logger::ERROR, InvalidProjectConfigError.new('send_odp_event').message)
         return
       end
+
+      if action.nil? || action.empty?
+        @logger.log(Logger::ERROR, Helpers::Constants::ODP_LOGS[:ODP_INVALID_ACTION])
+        return
+      end
+
+      type = Helpers::Constants::ODP_MANAGER_CONFIG[:EVENT_TYPE] if type.nil? || type.empty?
 
       @odp_manager.send_event(type: type, action: action, identifiers: identifiers, data: data)
     end

--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -387,7 +387,8 @@ module Optimizely
         ODP_EVENT_FAILED: 'ODP event send failed (%s).',
         ODP_NOT_ENABLED: 'ODP is not enabled.',
         ODP_NOT_INTEGRATED: 'ODP is not integrated.',
-        ODP_INVALID_DATA: 'ODP data is not valid.'
+        ODP_INVALID_DATA: 'ODP data is not valid.',
+        ODP_INVALID_ACTION: 'ODP action is not valid (cannot be empty).'
       }.freeze
 
       DECISION_NOTIFICATION_TYPES = {

--- a/spec/odp/odp_event_manager_spec.rb
+++ b/spec/odp/odp_event_manager_spec.rb
@@ -92,6 +92,20 @@ describe Optimizely::OdpEventManager do
       event[:data]['invalid-item'] = {}
       expect(Optimizely::Helpers::Validator.odp_data_types_valid?(event[:data])).to be false
     end
+
+    it 'should convert invalid event identifier' do
+      event = Optimizely::OdpEvent.new(type: 'type', action: 'action', identifiers: {'fs-user-id' => 'great'}, data: {})
+      expect(event.instance_variable_get('@identifiers')).to eq({'fs_user_id' => 'great'})
+
+      event = Optimizely::OdpEvent.new(type: 'type', action: 'action', identifiers: {'FS-user-ID' => 'great'}, data: {})
+      expect(event.instance_variable_get('@identifiers')).to eq({'fs_user_id' => 'great'})
+
+      event = Optimizely::OdpEvent.new(type: 'type', action: 'action', identifiers: {'FS_USER_ID' => 'great', 'fs.user.id' => 'wow'}, data: {})
+      expect(event.instance_variable_get('@identifiers')).to eq({'fs_user_id' => 'great', 'fs.user.id' => 'wow'})
+
+      event = Optimizely::OdpEvent.new(type: 'type', action: 'action', identifiers: {'fs_user_id' => 'great', 'fsuserid' => 'wow'}, data: {})
+      expect(event.instance_variable_get('@identifiers')).to eq({'fs_user_id' => 'great', 'fsuserid' => 'wow'})
+    end
   end
 
   describe '#initialize' do

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -4916,5 +4916,39 @@ describe 'Optimizely' do
 
       project.close
     end
+
+    it 'should log error with nil action' do
+      expect(spy_logger).to receive(:log).once.with(Logger::ERROR, 'ODP action is not valid (cannot be empty).')
+      project = Optimizely::Project.new(config_body_integrations_JSON, nil, spy_logger)
+      project.send_odp_event(type: 'wow', action: nil, identifiers: {amazing: 'fantastic'}, data: {})
+      project.close
+    end
+
+    it 'should log error with empty string action' do
+      expect(spy_logger).to receive(:log).once.with(Logger::ERROR, 'ODP action is not valid (cannot be empty).')
+      project = Optimizely::Project.new(config_body_integrations_JSON, nil, spy_logger)
+      project.send_odp_event(type: 'wow', action: '', identifiers: {amazing: 'fantastic'}, data: {})
+      project.close
+    end
+
+    it 'should use default with nil type' do
+      project = Optimizely::Project.new(config_body_integrations_JSON, nil, spy_logger)
+      expect(project.odp_manager).to receive('send_event').with(type: 'fullstack', action: 'great', identifiers: {amazing: 'fantastic'}, data: {})
+      project.send_odp_event(type: nil, action: 'great', identifiers: {amazing: 'fantastic'}, data: {})
+
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+
+      project.close
+    end
+
+    it 'should use default with empty string type' do
+      project = Optimizely::Project.new(config_body_integrations_JSON, nil, spy_logger)
+      expect(project.odp_manager).to receive('send_event').with(type: 'fullstack', action: 'great', identifiers: {amazing: 'fantastic'}, data: {})
+      project.send_odp_event(type: '', action: 'great', identifiers: {amazing: 'fantastic'}, data: {})
+
+      expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
+
+      project.close
+    end
   end
 end


### PR DESCRIPTION
Summary
-------
Add validation to send_odp_events:

- log error when action == None or ""
- use default when type == None or ""
- fix case and/or "-" for `fs_user_id` identifier key

Test plan
---------
added tests to:
odp_event_manager_spec.rb
project_spec.rb

Ticket
------
[FSSDK-9074](https://jira.sso.episerver.net/browse/FSSDK-9074)