### PR TITLE
[FSSDK-9509] Update http_project_config_manager.rb with soft log warning about polling interval < 30s

### DIFF
--- a/lib/optimizely/config_manager/http_project_config_manager.rb
+++ b/lib/optimizely/config_manager/http_project_config_manager.rb
@@ -268,7 +268,7 @@ module Optimizely
         return
       end
 
-      unless polling_interval.positive? && polling_interval < 30
+      if polling_interval < 30
         @logger.log(
           Logger::WARN,
           'Polling intervals below 30 seconds are not recommended.'

--- a/lib/optimizely/config_manager/http_project_config_manager.rb
+++ b/lib/optimizely/config_manager/http_project_config_manager.rb
@@ -270,7 +270,7 @@ module Optimizely
 
       unless polling_interval.positive? && polling_interval < 30
         @logger.log(
-          Logger::WARNING,
+          Logger::WARN,
           'Polling intervals below 30 seconds are not recommended.'
         )
       end

--- a/lib/optimizely/config_manager/http_project_config_manager.rb
+++ b/lib/optimizely/config_manager/http_project_config_manager.rb
@@ -274,7 +274,7 @@ module Optimizely
           'Polling intervals below 30 seconds are not recommended.'
         )
       end
-      
+
       @polling_interval = polling_interval
     end
 

--- a/lib/optimizely/config_manager/http_project_config_manager.rb
+++ b/lib/optimizely/config_manager/http_project_config_manager.rb
@@ -271,7 +271,7 @@ module Optimizely
       unless polling_interval.positive? && polling_interval < 30
         @logger.log(
           Logger::WARNING,
-          "Polling intervals below 30 seconds are not recommended."
+          'Polling intervals below 30 seconds are not recommended.'
         )
       end
       

--- a/lib/optimizely/config_manager/http_project_config_manager.rb
+++ b/lib/optimizely/config_manager/http_project_config_manager.rb
@@ -268,6 +268,13 @@ module Optimizely
         return
       end
 
+      unless polling_interval.positive? && polling_interval < 30
+        @logger.log(
+          Logger::WARNING,
+          "Polling intervals below 30 seconds are not recommended."
+        )
+      end
+      
       @polling_interval = polling_interval
     end
 


### PR DESCRIPTION
Add soft warning that polling interval under 30 s is not recommended.

## Summary
- To synchronize with ter SDKs. Peloton had an issue with setting polling interval too low. So we are adding this soft warning to all SDKs including Ruby.
- See Jira ticket below for more.

## Test plan
Unit tests

## Issues
- [FSSDK-9509](https://jira.sso.episerver.net/browse/FSSDK-9509)
