### PR TITLE
[FSSDK-9381] fix: remove config manager stop restriction

### DIFF
--- a/lib/optimizely/config_manager/http_project_config_manager.rb
+++ b/lib/optimizely/config_manager/http_project_config_manager.rb
@@ -102,11 +102,6 @@ module Optimizely
     end
 
     def start!
-      if @stopped
-        @logger.log(Logger::WARN, 'Not starting. Already stopped.')
-        return
-      end
-
       @async_scheduler.start!
       @stopped = false
     end


### PR DESCRIPTION
## Summary
- Remove the guard restricting the polling config manager from being restarted.


## Test plan

## Issues
- fixes https://github.com/optimizely/ruby-sdk/issues/237

## Ticket
[FSSDK-9381](https://jira.sso.episerver.net/browse/FSSDK-9381)
