### PR TITLE
[FSSDK-9382] switch client init args from positional to keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can initialize the Optimizely instance in two ways: directly with a datafile
  Initialize Optimizely with a datafile. This datafile will be used as ProjectConfig throughout the life of the Optimizely instance.
 
  ```ruby
- optimizely_instance = Optimizely::Project.new(datafile)
+ optimizely_instance = Optimizely::Project.new(datafile: datafile)
  ```
 
 #### Initialization by OptimizelyFactory

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -70,20 +70,20 @@ module Optimizely
     # @param event_processor_options: Optional hash of options to be passed to the default batch event processor.
     # @param settings: Optional instance of OptimizelySdkSettings for sdk configuration.
 
-    def initialize( # rubocop:disable Metrics/ParameterLists
-      datafile = nil,
-      event_dispatcher = nil,
-      logger = nil,
-      error_handler = nil,
-      skip_json_validation = false, # rubocop:disable Style/OptionalBooleanParameter
-      user_profile_service = nil,
-      sdk_key = nil,
-      config_manager = nil,
-      notification_center = nil,
-      event_processor = nil,
-      default_decide_options = [],
-      event_processor_options = {},
-      settings = nil
+    def initialize(
+      datafile: nil,
+      event_dispatcher: nil,
+      logger: nil,
+      error_handler: nil,
+      skip_json_validation: false,
+      user_profile_service: nil,
+      sdk_key: nil,
+      config_manager: nil,
+      notification_center: nil,
+      event_processor: nil,
+      default_decide_options: [],
+      event_processor_options: {},
+      settings: nil
     )
       @logger = logger || NoOpLogger.new
       @error_handler = error_handler || NoOpErrorHandler.new

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -59,7 +59,7 @@ module Optimizely
       user_condition_evaluator = UserConditionEvaluator.new(user_context, logger)
 
       evaluate_user_conditions = lambda do |condition|
-        return user_condition_evaluator.evaluate(condition)
+        user_condition_evaluator.evaluate(condition)
       end
 
       evaluate_audience = lambda do |audience_id|

--- a/lib/optimizely/audience.rb
+++ b/lib/optimizely/audience.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2017, 2019-2020, Optimizely and contributors
+#    Copyright 2016-2017, 2019-2020, 2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/event/event_factory.rb
+++ b/lib/optimizely/event/event_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2019-2020, 2022, Optimizely and contributors
+#    Copyright 2019-2020, 2022-2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/event/event_factory.rb
+++ b/lib/optimizely/event/event_factory.rb
@@ -72,7 +72,7 @@ module Optimizely
 
       def build_attribute_list(user_attributes, project_config)
         visitor_attributes = []
-        user_attributes&.keys&.each do |attribute_key|
+        user_attributes&.each_key do |attribute_key|
           # Omit attribute values that are not supported by the log endpoint.
           attribute_value = user_attributes[attribute_key]
           next unless Helpers::Validator.attribute_valid?(attribute_key, attribute_value)

--- a/lib/optimizely/event_builder.rb
+++ b/lib/optimizely/event_builder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2019, 2022, Optimizely and contributors
+#    Copyright 2016-2019, 2022-2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/event_builder.rb
+++ b/lib/optimizely/event_builder.rb
@@ -62,7 +62,7 @@ module Optimizely
 
       visitor_attributes = []
 
-      attributes&.keys&.each do |attribute_key|
+      attributes&.each_key do |attribute_key|
         # Omit attribute values that are not supported by the log endpoint.
         attribute_value = attributes[attribute_key]
         if Helpers::Validator.attribute_valid?(attribute_key, attribute_value)

--- a/lib/optimizely/helpers/validator.rb
+++ b/lib/optimizely/helpers/validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2019, 2022, Optimizely and contributors
+#    Copyright 2016-2019, 2022-2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/lib/optimizely/helpers/validator.rb
+++ b/lib/optimizely/helpers/validator.rb
@@ -190,14 +190,13 @@ module Optimizely
         # segments_cache - custom cache to be validated.
         #
         # Returns boolean depending on whether cache has required methods.
-        (
-          segments_cache.respond_to?(:reset) &&
+
+        segments_cache.respond_to?(:reset) &&
           segments_cache.method(:reset)&.parameters&.empty? &&
           segments_cache.respond_to?(:lookup) &&
           segments_cache.method(:lookup)&.parameters&.length&.positive? &&
           segments_cache.respond_to?(:save) &&
           segments_cache.method(:save)&.parameters&.length&.positive?
-        )
       end
 
       def segment_manager_valid?(segment_manager)
@@ -206,13 +205,12 @@ module Optimizely
         # segment_manager - custom manager to be validated.
         #
         # Returns boolean depending on whether manager has required methods.
-        (
-          segment_manager.respond_to?(:odp_config) &&
+
+        segment_manager.respond_to?(:odp_config) &&
           segment_manager.respond_to?(:reset) &&
           segment_manager.method(:reset)&.parameters&.empty? &&
           segment_manager.respond_to?(:fetch_qualified_segments) &&
           (segment_manager.method(:fetch_qualified_segments)&.parameters&.length || 0) >= 3
-        )
       end
 
       def event_manager_valid?(event_manager)

--- a/lib/optimizely/optimizely_factory.rb
+++ b/lib/optimizely/optimizely_factory.rb
@@ -103,7 +103,7 @@ module Optimizely
       )
 
       Optimizely::Project.new(
-        datafile, nil, logger, error_handler, nil, nil, sdk_key, config_manager, notification_center
+        datafile: datafile, logger: logger, error_handler: error_handler, sdk_key: sdk_key, config_manager: config_manager, notification_center: notification_center
       )
     end
 
@@ -111,7 +111,7 @@ module Optimizely
     #
     # @param config_manager - Required ConfigManagerInterface Responds to 'config' method.
     def self.default_instance_with_config_manager(config_manager)
-      Optimizely::Project.new(nil, nil, nil, nil, nil, nil, nil, config_manager)
+      Optimizely::Project.new(config_manager: config_manager)
     end
 
     # Returns a new optimizely instance.
@@ -167,19 +167,17 @@ module Optimizely
       )
 
       Optimizely::Project.new(
-        datafile,
-        event_dispatcher,
-        logger,
-        error_handler,
-        skip_json_validation,
-        user_profile_service,
-        sdk_key,
-        config_manager,
-        notification_center,
-        event_processor,
-        [],
-        {},
-        settings
+        datafile: datafile,
+        event_dispatcher: event_dispatcher,
+        logger: logger,
+        error_handler: error_handler,
+        skip_json_validation: skip_json_validation,
+        user_profile_service: user_profile_service,
+        sdk_key: sdk_key,
+        config_manager: config_manager,
+        notification_center: notification_center,
+        event_processor: event_processor,
+        settings: settings
       )
     end
   end

--- a/lib/optimizely/optimizely_factory.rb
+++ b/lib/optimizely/optimizely_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2019, 2022, Optimizely and contributors
+#    Copyright 2019, 2022-2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/audience_spec.rb
+++ b/spec/audience_spec.rb
@@ -25,7 +25,7 @@ describe Optimizely::Audience do
   let(:config) { Optimizely::DatafileProjectConfig.new(config_body_JSON, spy_logger, error_handler) }
   let(:typed_audience_config) { Optimizely::DatafileProjectConfig.new(config_typed_audience_JSON, spy_logger, error_handler) }
   let(:integration_config) { Optimizely::DatafileProjectConfig.new(config_integration_JSON, spy_logger, error_handler) }
-  let(:project_instance) { Optimizely::Project.new(config_body_JSON, nil, spy_logger, error_handler) }
+  let(:project_instance) { Optimizely::Project.new(datafile: config_body_JSON, logger: spy_logger, error_handler: error_handler) }
   let(:user_context) { project_instance.create_user_context('some-user', {}) }
   after(:example) { project_instance.close }
 

--- a/spec/audience_spec.rb
+++ b/spec/audience_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2017, 2019-2020, 2022, Optimizely and contributors
+#    Copyright 2016-2017, 2019-2020, 2022-2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/condition_tree_evaluator_spec.rb
+++ b/spec/condition_tree_evaluator_spec.rb
@@ -27,19 +27,19 @@ describe Optimizely::ConditionTreeEvaluator do
 
   describe 'evaluate' do
     it 'should return true for a leaf condition when the leaf condition evaluator returns true' do
-      leaf_callback = ->(_condition) { return true }
+      leaf_callback = ->(_condition) { true }
       expect(Optimizely::ConditionTreeEvaluator.evaluate(@browser_condition, leaf_callback)).to be true
     end
 
     it 'should return false for a leaf condition when the leaf condition evaluator returns false' do
-      leaf_callback = ->(_condition) { return false }
+      leaf_callback = ->(_condition) { false }
       expect(Optimizely::ConditionTreeEvaluator.evaluate(@browser_condition, leaf_callback)).to be false
     end
   end
 
   describe 'and evaluation' do
     it 'should return true when ALL conditions evaluate to true' do
-      leaf_callback = ->(_condition) { return true }
+      leaf_callback = ->(_condition) { true }
       expect(Optimizely::ConditionTreeEvaluator.evaluate(['and', @browser_condition, @device_condition], leaf_callback)).to be true
     end
 
@@ -51,7 +51,7 @@ describe Optimizely::ConditionTreeEvaluator do
 
     describe 'nil handling' do
       it 'should return nil when all operands evaluate to nil' do
-        leaf_callback = ->(_condition) { return nil }
+        leaf_callback = ->(_condition) { nil }
         expect(Optimizely::ConditionTreeEvaluator.evaluate(['and', @browser_condition, @device_condition], leaf_callback)).to eq(nil)
       end
 
@@ -83,7 +83,7 @@ describe Optimizely::ConditionTreeEvaluator do
 
   describe 'or evaluation' do
     it 'should return false if all conditions evaluate to false' do
-      leaf_callback = ->(_condition) { return false }
+      leaf_callback = ->(_condition) { false }
       expect(Optimizely::ConditionTreeEvaluator.evaluate(['or', @browser_condition, @device_condition], leaf_callback)).to be false
     end
 
@@ -95,7 +95,7 @@ describe Optimizely::ConditionTreeEvaluator do
 
     describe 'nil handling' do
       it 'should return nil when all operands evaluate to nil' do
-        leaf_callback = ->(_condition) { return nil }
+        leaf_callback = ->(_condition) { nil }
         expect(Optimizely::ConditionTreeEvaluator.evaluate(['or', @browser_condition, @device_condition], leaf_callback)).to eq(nil)
       end
 
@@ -127,34 +127,34 @@ describe Optimizely::ConditionTreeEvaluator do
 
   describe 'not evaluation' do
     it 'should return true if the condition evaluates to false' do
-      leaf_callback = ->(_condition) { return false }
+      leaf_callback = ->(_condition) { false }
       expect(Optimizely::ConditionTreeEvaluator.evaluate(['not', @browser_condition], leaf_callback)).to be true
     end
 
     it 'should return false if the condition evaluates to true' do
-      leaf_callback = ->(_condition) { return true }
+      leaf_callback = ->(_condition) { true }
       expect(Optimizely::ConditionTreeEvaluator.evaluate(['not', @browser_condition], leaf_callback)).to be false
     end
 
     it 'should return the result of negating the first condition, and ignore any additional conditions' do
-      leaf_callback = ->(id) { return id == '1' }
+      leaf_callback = ->(id) { id == '1' }
       expect(Optimizely::ConditionTreeEvaluator.evaluate(%w[not 1 2 1], leaf_callback)).to be false
 
-      leaf_callback2 = ->(id) { return id == '2' }
+      leaf_callback2 = ->(id) { id == '2' }
       expect(Optimizely::ConditionTreeEvaluator.evaluate(%w[not 1 2 1], leaf_callback2)).to be true
 
-      leaf_callback3 = ->(id) { return id == '1' ? nil : id == '3' }
+      leaf_callback3 = ->(id) { id == '1' ? nil : id == '3' }
       expect(Optimizely::ConditionTreeEvaluator.evaluate(%w[not 1 2 3], leaf_callback3)).to eq(nil)
     end
 
     describe 'nil handling' do
       it 'should return nil when operand evaluates to nil' do
-        leaf_callback = ->(_condition) { return nil }
+        leaf_callback = ->(_condition) { nil }
         expect(Optimizely::ConditionTreeEvaluator.evaluate(['not', @browser_condition, @device_condition], leaf_callback)).to eq(nil)
       end
 
       it 'should return nil when there are no operands' do
-        leaf_callback = ->(_condition) { return nil }
+        leaf_callback = ->(_condition) { nil }
         expect(Optimizely::ConditionTreeEvaluator.evaluate(['not'], leaf_callback)).to eq(nil)
       end
     end
@@ -166,7 +166,7 @@ describe Optimizely::ConditionTreeEvaluator do
       allow(leaf_callback).to receive(:call).and_return(true, false)
       expect(Optimizely::ConditionTreeEvaluator.evaluate([@browser_condition, @device_condition], leaf_callback)).to be true
 
-      leaf_callback = ->(_condition) { return false }
+      leaf_callback = ->(_condition) { false }
       allow(leaf_callback).to receive(:call).and_return(false, true)
       expect(Optimizely::ConditionTreeEvaluator.evaluate([@browser_condition, @device_condition], leaf_callback)).to be true
     end

--- a/spec/condition_tree_evaluator_spec.rb
+++ b/spec/condition_tree_evaluator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2019, Optimizely and contributors
+#    Copyright 2019, 2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2017-2020, Optimizely and contributors
+#    Copyright 2017-2020, 2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -28,7 +28,7 @@ describe Optimizely::DecisionService do
   let(:spy_user_profile_service) { spy('user_profile_service') }
   let(:config) { Optimizely::DatafileProjectConfig.new(config_body_JSON, spy_logger, error_handler) }
   let(:decision_service) { Optimizely::DecisionService.new(spy_logger, spy_user_profile_service) }
-  let(:project_instance) { Optimizely::Project.new(config_body_JSON, nil, spy_logger, error_handler) }
+  let(:project_instance) { Optimizely::Project.new(datafile: config_body_JSON, logger: spy_logger, error_handler: error_handler) }
   let(:user_context) { project_instance.create_user_context('some-user', {}) }
   after(:example) { project_instance.close }
 
@@ -497,7 +497,7 @@ describe Optimizely::DecisionService do
 
   describe '#get_variation_for_feature_experiment' do
     config_body_json = OptimizelySpec::VALID_CONFIG_BODY_JSON
-    project_instance = Optimizely::Project.new(config_body_json, nil, nil, nil)
+    project_instance = Optimizely::Project.new(datafile: config_body_json)
     user_context = project_instance.create_user_context('user_1', {})
 
     describe 'when the feature flag\'s experiment ids array is empty' do
@@ -619,7 +619,7 @@ describe Optimizely::DecisionService do
 
   describe '#get_variation_for_feature_rollout' do
     config_body_json = OptimizelySpec::VALID_CONFIG_BODY_JSON
-    project_instance = Optimizely::Project.new(config_body_json, nil, nil, nil)
+    project_instance = Optimizely::Project.new(datafile: config_body_json)
     user_context = project_instance.create_user_context('user_1', {})
     user_id = 'user_1'
 
@@ -816,7 +816,7 @@ describe Optimizely::DecisionService do
 
   describe '#get_variation_for_feature' do
     config_body_json = OptimizelySpec::VALID_CONFIG_BODY_JSON
-    project_instance = Optimizely::Project.new(config_body_json, nil, nil, nil)
+    project_instance = Optimizely::Project.new(datafile: config_body_json)
     user_context = project_instance.create_user_context('user_1', {})
 
     describe 'when the user is bucketed into the feature experiment' do

--- a/spec/notification_center_registry_spec.rb
+++ b/spec/notification_center_registry_spec.rb
@@ -42,7 +42,7 @@ describe Optimizely::NotificationCenter do
         stub_request(:get, "https://cdn.optimizely.com/datafiles/#{sdk_key}.json")
           .to_return(status: 200, body: config_body_JSON)
 
-        project = Optimizely::Project.new(nil, nil, spy_logger, nil, false, nil, sdk_key)
+        project = Optimizely::Project.new(logger: spy_logger, sdk_key: sdk_key)
 
         notification_center = Optimizely::NotificationCenterRegistry.get_notification_center(sdk_key, spy_logger)
         expect(notification_center).to be_a Optimizely::NotificationCenter
@@ -60,7 +60,7 @@ describe Optimizely::NotificationCenter do
           .to_return(status: 200, body: config_body_JSON)
 
         notification_center = Optimizely::NotificationCenterRegistry.get_notification_center(sdk_key, spy_logger)
-        project = Optimizely::Project.new(nil, nil, spy_logger, nil, false, nil, sdk_key)
+        project = Optimizely::Project.new(logger: spy_logger, sdk_key: sdk_key)
 
         expect(notification_center).to eq(Optimizely::NotificationCenterRegistry.get_notification_center(sdk_key, spy_logger))
         expect(spy_logger).not_to have_received(:log).with(Logger::ERROR, anything)
@@ -78,7 +78,7 @@ describe Optimizely::NotificationCenter do
         notification_center = Optimizely::NotificationCenterRegistry.get_notification_center(sdk_key, spy_logger)
         expect(notification_center).to receive(:send_notifications).once
 
-        project = Optimizely::Project.new(nil, nil, spy_logger, nil, false, nil, sdk_key)
+        project = Optimizely::Project.new(logger: spy_logger, sdk_key: sdk_key)
         project.config_manager.config
 
         Optimizely::NotificationCenterRegistry.remove_notification_center(sdk_key)

--- a/spec/optimizely_config_spec.rb
+++ b/spec/optimizely_config_spec.rb
@@ -26,16 +26,16 @@ describe Optimizely::OptimizelyConfig do
   let(:error_handler) { Optimizely::NoOpErrorHandler.new }
   let(:spy_logger) { spy('logger') }
   let(:project_config) { Optimizely::DatafileProjectConfig.new(config_body_JSON, spy_logger, error_handler) }
-  let(:project_instance) { Optimizely::Project.new(config_body_JSON, nil, spy_logger, error_handler) }
+  let(:project_instance) { Optimizely::Project.new(datafile: config_body_JSON, logger: spy_logger, error_handler: error_handler) }
   let(:optimizely_config) { project_instance.get_optimizely_config }
   let(:project_config_sim_keys) { Optimizely::DatafileProjectConfig.new(similar_exp_keys_JSON, spy_logger, error_handler) }
-  let(:project_instance_sim_keys) { Optimizely::Project.new(similar_exp_keys_JSON, nil, spy_logger, error_handler) }
+  let(:project_instance_sim_keys) { Optimizely::Project.new(datafile: similar_exp_keys_JSON, logger: spy_logger, error_handler: error_handler) }
   let(:optimizely_config_sim_keys) { project_instance_sim_keys.get_optimizely_config }
   let(:project_config_typed_audiences) { Optimizely::DatafileProjectConfig.new(typed_audiences_JSON, spy_logger, error_handler) }
-  let(:project_instance_typed_audiences) { Optimizely::Project.new(typed_audiences_JSON, nil, spy_logger, error_handler) }
+  let(:project_instance_typed_audiences) { Optimizely::Project.new(datafile: typed_audiences_JSON, logger: spy_logger, error_handler: error_handler) }
   let(:optimizely_config_typed_audiences) { project_instance_typed_audiences.get_optimizely_config }
   let(:project_config_similar_rule_keys) { Optimizely::DatafileProjectConfig.new(similar_rule_key_JSON, spy_logger, error_handler) }
-  let(:project_instance_similar_rule_keys) { Optimizely::Project.new(similar_rule_key_JSON, nil, spy_logger, error_handler) }
+  let(:project_instance_similar_rule_keys) { Optimizely::Project.new(datafile: similar_rule_key_JSON, logger: spy_logger, error_handler: error_handler) }
   let(:optimizely_config_similar_rule_keys) { project_instance_similar_rule_keys.get_optimizely_config }
   after(:example) do
     project_instance.close

--- a/spec/optimizely_config_spec.rb
+++ b/spec/optimizely_config_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2019-2021, Optimizely and contributors
+#    Copyright 2019-2021, 2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/optimizely_user_context_spec.rb
+++ b/spec/optimizely_user_context_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2020, 2022, Optimizely and contributors
+#    Copyright 2020, 2022-2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/spec/optimizely_user_context_spec.rb
+++ b/spec/optimizely_user_context_spec.rb
@@ -27,9 +27,9 @@ describe 'Optimizely' do
   let(:integration_JSON) { OptimizelySpec::CONFIG_DICT_WITH_INTEGRATIONS_JSON }
   let(:error_handler) { Optimizely::RaiseErrorHandler.new }
   let(:spy_logger) { spy('logger') }
-  let(:project_instance) { Optimizely::Project.new(config_body_JSON, nil, spy_logger, error_handler) }
-  let(:forced_decision_project_instance) { Optimizely::Project.new(forced_decision_JSON, nil, spy_logger, error_handler, false, nil, nil, nil, nil, nil, [], {batch_size: 1}) }
-  let(:integration_project_instance) { Optimizely::Project.new(integration_JSON, nil, spy_logger, error_handler) }
+  let(:project_instance) { Optimizely::Project.new(datafile: config_body_JSON, logger: spy_logger, error_handler: error_handler) }
+  let(:forced_decision_project_instance) { Optimizely::Project.new(datafile: forced_decision_JSON, logger: spy_logger, error_handler: error_handler, event_processor_options: {batch_size: 1}) }
+  let(:integration_project_instance) { Optimizely::Project.new(datafile: integration_JSON, logger: spy_logger, error_handler: error_handler) }
   let(:impression_log_url) { 'https://logx.optimizely.com/v1/events' }
   let(:good_response_data) do
     {

--- a/spec/user_condition_evaluator_spec.rb
+++ b/spec/user_condition_evaluator_spec.rb
@@ -28,7 +28,7 @@ describe Optimizely::UserConditionEvaluator do
   let(:error_handler) { Optimizely::NoOpErrorHandler.new }
   let(:spy_logger) { spy('logger') }
   let(:event_processor) { Optimizely::ForwardingEventProcessor.new(Optimizely::EventDispatcher.new) }
-  let(:project_instance) { Optimizely::Project.new(config_body_JSON, nil, spy_logger, error_handler, false, nil, nil, nil, nil, event_processor) }
+  let(:project_instance) { Optimizely::Project.new(datafile: config_body_JSON, logger: spy_logger, error_handler: error_handler, event_processor: event_processor) }
   let(:user_context) { project_instance.create_user_context('some-user', {}) }
   after(:example) { project_instance.close }
 

--- a/spec/user_condition_evaluator_spec.rb
+++ b/spec/user_condition_evaluator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2019-2020, Optimizely and contributors
+#    Copyright 2019-2020, 2023, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
The Optimizely constructor uses positional args and since all of them are optional, it can become unwieldy.

This PR changes the positional args to keyword.

## Ticket
[FSSDK-9382](https://jira.sso.episerver.net/browse/FSSDK-9382)

## Issues
https://github.com/optimizely/ruby-sdk/issues/243
