### PR TITLE
Introduce ForkTracker to automatically restart threads

### DIFF
--- a/lib/optimizely/event/batch_event_processor.rb
+++ b/lib/optimizely/event/batch_event_processor.rb
@@ -16,6 +16,7 @@
 #    limitations under the License.
 #
 require_relative 'event_processor'
+require_relative '../fork_tracker'
 require_relative '../helpers/validator'
 module Optimizely
   class BatchEventProcessor < EventProcessor
@@ -77,6 +78,7 @@ module Optimizely
         @resource = ConditionVariable.new
       end
       @thread = Thread.new { run_queue }
+      ForkTracker.after_fork { @thread = Thread.new { run_queue } }
       @started = true
       @stopped = false
     end

--- a/lib/optimizely/fork_tracker.rb
+++ b/lib/optimizely/fork_tracker.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# This class is used for re-starting of threads after a fork
+# Sourced from https://github.com/rails/rails/blob/a44559679aa26a54ea9867a68a78c5a4a55a3b9f/activesupport/lib/active_support/fork_tracker.rb
+
+module Optimizely
+  module ForkTracker
+    module ModernCoreExt
+      def _fork
+        pid = super
+        ForkTracker.after_fork_callback if pid.zero?
+        pid
+      end
+    end
+
+    module CoreExt
+      def fork(...)
+        if block_given?
+          super do
+            ForkTracker.check!
+            yield
+          end
+        else
+          unless (pid = super)
+            ForkTracker.check!
+          end
+          pid
+        end
+      end
+    end
+
+    module CoreExtPrivate
+      include CoreExt
+      private :fork
+    end
+
+    @pid = Process.pid
+    @callbacks = []
+
+    class << self
+      def after_fork_callback
+        new_pid = Process.pid
+        return unless @pid != new_pid
+
+        @callbacks.each(&:call)
+        @pid = new_pid
+      end
+
+      if Process.respond_to?(:_fork) # Ruby 3.1+
+        def check!
+          # We trust the `_fork` callback
+        end
+      else
+        alias check! after_fork_callback
+      end
+
+      def hook!
+        if Process.respond_to?(:_fork) # Ruby 3.1+
+          ::Process.singleton_class.prepend(ModernCoreExt)
+        elsif Process.respond_to?(:fork)
+          ::Object.prepend(CoreExtPrivate) if RUBY_VERSION < '3.0'
+          ::Kernel.prepend(CoreExtPrivate)
+          ::Kernel.singleton_class.prepend(CoreExt)
+          ::Process.singleton_class.prepend(CoreExt)
+        end
+      end
+
+      def after_fork(&block)
+        @callbacks << block
+        block
+      end
+
+      def unregister(callback)
+        @callbacks.delete(callback)
+      end
+    end
+  end
+end
+
+Optimizely::ForkTracker.hook!

--- a/lib/optimizely/odp/odp_event_manager.rb
+++ b/lib/optimizely/odp/odp_event_manager.rb
@@ -18,6 +18,7 @@
 require_relative 'odp_event_api_manager'
 require_relative '../helpers/constants'
 require_relative 'odp_event'
+require_relative '../fork_tracker'
 
 module Optimizely
   class OdpEventManager
@@ -68,6 +69,7 @@ module Optimizely
       @api_key = odp_config.api_key
 
       @thread = Thread.new { run }
+      ForkTracker.after_fork { @thread = Thread.new { run } }
       @logger.log(Logger::INFO, 'Starting scheduler.')
     end
 


### PR DESCRIPTION
## Summary

### The Problem

When running puma or unicorn with multiple workers, they do some initial work in a process. When configured to preload the app, this can include the initialization of `Optimizely::Project` instances. When these objects are instantiated, there are threads that get started.

After the initial process is done with its work, it forks into new processes. This kills the threads.

This is documented [here](https://docs.developers.optimizely.com/full-stack-experimentation/docs/initialize-sdk-ruby#initializing-in-a-rails-application) but requires updating the server config. Instead, making the gem responsible for re-starting the threads itself removes this footgun and makes the initial setup easier.

Side note: If there's no appetite for including this or a similar change in the gem itself, adding that documentation to the README and the Ruby quickstart guide would be helpful. It took us awhile to track down what was happening 😅 

### The Fix

This proof of concept copies over Rails' `ActiveSupport::ForkTracker` that hooks into `Process._fork` and allows us to re-start the threads automatically after forking. No extra configuration is needed by the user of the gem.

As an alternative approach, the DataDog gem [handles this nicely as well](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/core/utils/forking.rb) and could be used as inspiration.

## Test plan

In an app that includes the gem, start puma or unicorn with multiple workers and see that the Optimizely classes no longer need to be re-initialized after forking and the datafile continues to be updated, etc.
