### PR TITLE
[FSSDK-9951] add multi thread warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ You can initialize the Optimizely instance in two ways: directly with a datafile
       )
       ```
 
+**Note:** The SDK spawns multiple threads when initialized. These threads have infinite loops that are used for fetching the datafile, as well as batching and dispatching events in the background. When using in a web server that spawn multiple child processes, you need to initialize the SDK after those child processes or workers have been spawned.
+
 #### HTTP Config Manager
 
 The `HTTPConfigManager` asynchronously polls for datafiles from a specified URL at regular intervals by making HTTP requests.

--- a/lib/optimizely/event_builder.rb
+++ b/lib/optimizely/event_builder.rb
@@ -65,17 +65,17 @@ module Optimizely
       attributes&.each_key do |attribute_key|
         # Omit attribute values that are not supported by the log endpoint.
         attribute_value = attributes[attribute_key]
-        if Helpers::Validator.attribute_valid?(attribute_key, attribute_value)
-          attribute_id = project_config.get_attribute_id attribute_key
-          if attribute_id
-            visitor_attributes.push(
-              entity_id: attribute_id,
-              key: attribute_key,
-              type: CUSTOM_ATTRIBUTE_FEATURE_TYPE,
-              value: attribute_value
-            )
-          end
-        end
+        next unless Helpers::Validator.attribute_valid?(attribute_key, attribute_value)
+
+        attribute_id = project_config.get_attribute_id attribute_key
+        next unless attribute_id
+
+        visitor_attributes.push(
+          entity_id: attribute_id,
+          key: attribute_key,
+          type: CUSTOM_ATTRIBUTE_FEATURE_TYPE,
+          value: attribute_value
+        )
       end
       # Append Bot Filtering Attribute
       if project_config.bot_filtering == true || project_config.bot_filtering == false


### PR DESCRIPTION
## Summary
- Add a warning to the readme about using the ruby sdk in a multi threaded environment.

## Test plan

## Issues
[FSSDK-9951](https://jira.sso.episerver.net/browse/FSSDK-9951)
[#344](https://github.com/optimizely/ruby-sdk/pull/344)
