### PR TITLE
[FSSDK-10765] enhancement: Implement UPS request batching for decideForKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ If you enable event batching, make sure that you call the `close` method, `optim
 
 For Further details see the Optimizely [Feature Experimentation documentation](https://docs.developers.optimizely.com/experimentation/v4.0.0-full-stack/docs/welcome)
 to learn how to set up your first Ruby project and use the SDK.
-This is a test line.
 
 ## SDK Development
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ If you enable event batching, make sure that you call the `close` method, `optim
 
 For Further details see the Optimizely [Feature Experimentation documentation](https://docs.developers.optimizely.com/experimentation/v4.0.0-full-stack/docs/welcome)
 to learn how to set up your first Ruby project and use the SDK.
+This is a test line.
 
 ## SDK Development
 

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -1028,10 +1028,9 @@ module Optimizely
       return nil unless user_inputs_valid?(attributes)
 
       user_context = OptimizelyUserContext.new(self, user_id, attributes, identify: false)
-      user_profile_tracker = UserProfileTracker.new(user_id, @decision_service, @logger)
+      user_profile_tracker = UserProfileTracker.new(user_id, @user_profile_service, @logger)
       user_profile_tracker.load_user_profile
-      #TODO: Pass user profile tracker to decision service
-      variation_id, = @decision_service.get_variation(config, experiment_id, user_context)
+      variation_id, = @decision_service.get_variation(config, experiment_id, user_context, user_profile_tracker)
       user_profile_tracker.save_user_profile
       variation = config.get_variation_from_id(experiment_key, variation_id) unless variation_id.nil?
       variation_key = variation['key'] if variation

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -245,7 +245,7 @@ module Optimizely
       # Generate all variables map if decide options doesn't include excludeVariables
       unless decide_options.include? OptimizelyDecideOption::EXCLUDE_VARIABLES
         feature_flag['variables'].each do |variable|
-          variable_value = get_feature_variable_for_variation(key, feature_enabled, variation, variable, user_id)
+          variable_value = get_feature_variable_for_variation(flag_key, feature_enabled, variation, variable, user_id)
           all_variables[variable['key']] = Helpers::VariableType.cast_value_to_type(variable_value, variable['type'], @logger)
         end
       end
@@ -294,7 +294,7 @@ module Optimizely
       decide_for_keys(user_context, keys, decide_options)
     end
 
-    def decide_for_keys(user_context, keys, decide_options = [], ignore_default_options: false)
+    def decide_for_keys(user_context, keys, decide_options = [], ignore_default_options = false) # rubocop:disable Style/OptionalBooleanParameter
       # raising on user context as it is internal and not provided directly by the user.
       raise if user_context.class != OptimizelyUserContext
 
@@ -348,11 +348,7 @@ module Optimizely
           flag_decisions[key] = decision
         else
           flags_without_forced_decision.push(feature_flag)
-          # decision, reasons_received = @decision_service.get_variation_for_feature(config, feature_flag, user_context, decide_options)
-          # reasons.push(*reasons_received)
         end
-        # decision = decide(user_context, key, decide_options)
-        # decisions[key] = decision unless enabled_flags_only && !decision.enabled
       end
 
       decision_list = @decision_service.get_variations_for_feature_list(config, flags_without_forced_decision, user_context, decide_options)
@@ -360,7 +356,7 @@ module Optimizely
       flags_without_forced_decision.each_with_index do |flag, i|
         decision = decision_list[i][0]
         reasons = decision_list[i][1]
-        flag_key = flag.key
+        flag_key = flag['key']
         flag_decisions[flag_key] = decision
         decision_reasons_dict[flag_key] ||= []
         decision_reasons_dict[flag_key] += reasons

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -63,7 +63,7 @@ module Optimizely
       #
       # Returns variation ID where visitor will be bucketed
       #   (nil if experiment is inactive or user does not meet audience conditions)
-      user_profile_tracker = nil unless user_profile_tracker.is_a?(Optimizely::UserProfileTracker)
+      user_profile_tracker = UserProfileTracker.new(user_context.user_id, @user_profile_service, @logger) unless user_profile_tracker.is_a?(Optimizely::UserProfileTracker)
       decide_reasons = []
       decide_reasons.push(*reasons)
       user_id = user_context.user_id

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -170,9 +170,8 @@ module Optimizely
         decide_reasons = []
         # check if the feature is being experiment on and whether the user is bucketed into the experiment
         decision, reasons_received = get_variation_for_feature_experiment(project_config, feature_flag, user_context, user_profile_tracker, decide_options)
+        decide_reasons.push(*reasons_received)
         if decision
-          # Push the decision and reasons to decisions if the decision is not nil
-          decide_reasons.push(*reasons_received)
           decisions << [decision, decide_reasons]
         else
           # Proceed to rollout if the decision is nil

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -179,7 +179,7 @@ module Optimizely
           decisions << [rollout_decision, decide_reasons]
         end
       end
-      user_profile_tracker.save_user_profile unless user_profile_tracker
+      user_profile_tracker&.save_user_profile
       decisions
     end
 

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -94,7 +94,6 @@ module Optimizely
       return whitelisted_variation_id, decide_reasons if whitelisted_variation_id
 
       should_ignore_user_profile_service = decide_options.include? Optimizely::Decide::OptimizelyDecideOption::IGNORE_USER_PROFILE_SERVICE
-      # user_profile_tracker = Optimizely::UserProfileTracker.new(user_context.user_id, @user_profile_service, @logger) if user_profile_tracker.nil?
       # Check for saved bucketing decisions if decide_options do not include ignoreUserProfileService
       unless should_ignore_user_profile_service && user_profile_tracker
         saved_variation_id, reasons_received = get_saved_variation_id(project_config, experiment_id, user_profile_tracker.user_profile)

--- a/lib/optimizely/helpers/validator.rb
+++ b/lib/optimizely/helpers/validator.rb
@@ -122,11 +122,11 @@ module Optimizely
 
         return false unless variables.respond_to?(:each) && !variables.empty?
 
-        is_valid = true
+        is_valid = true # rubocop:disable Lint/UselessAssignment
         if variables.include? :user_id
           # Empty str is a valid user ID.
           unless variables[:user_id].is_a?(String)
-            is_valid = false
+            is_valid = false # rubocop:disable Lint/UselessAssignment
             logger.log(level, "#{Constants::INPUT_VARIABLES['USER_ID']} is invalid")
           end
           variables.delete :user_id

--- a/lib/optimizely/optimizely_factory.rb
+++ b/lib/optimizely/optimizely_factory.rb
@@ -142,7 +142,6 @@ module Optimizely
       notification_center = nil,
       settings = nil
     )
-
       error_handler ||= NoOpErrorHandler.new
       logger ||= NoOpLogger.new
       notification_center = notification_center.is_a?(Optimizely::NotificationCenter) ? notification_center : NotificationCenter.new(logger, error_handler)

--- a/lib/optimizely/user_profile_tracker.rb
+++ b/lib/optimizely/user_profile_tracker.rb
@@ -21,9 +21,9 @@ module Optimizely
       return if reasons.nil?
 
       begin
-        @user_profile = @user_profile_service.lookup(user_id) || @user_profile
+        @user_profile = @user_profile_service.lookup(@user_id) || @user_profile
       rescue => e
-        message = "Error while loading user profile in user profile tracker for user ID '#{user_id}': #{e}."
+        message = "Error while loading user profile in user profile tracker for user ID '#{@user_id}': #{e}."
         reasons << e.message
         @logger.log(Logger::ERROR, message)
         error_handler&.handle_error(e)

--- a/lib/optimizely/user_profile_tracker.rb
+++ b/lib/optimizely/user_profile_tracker.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Optimizely
+  class UserProfileTracker
+    attr_reader :user_profile
+
+    def initialize(user_id, user_profile_service = nil, logger = nil)
+      @user_id = user_id
+      @user_profile_service = user_profile_service
+      @logger = logger || NoOpLogger.new
+      @profile_updated = false
+      @user_profile = {
+        user_id: user_id,
+        experiment_bucket_map: {}
+      }
+    end
+
+    def load_user_profile(reasons = [], error_handler = nil)
+      return if reasons.nil?
+
+      begin
+        @user_profile = @user_profile_service.lookup(user_id) || @user_profile
+      rescue => e
+        message = "Error while loading user profile in user profile tracker for user ID '#{user_id}': #{e}."
+        reasons << e.message
+        @logger.log(Logger::ERROR, message)
+        error_handler&.handle_error(e)
+      end
+    end
+
+    def update_user_profile(experiment_id, variation_id)
+      user_id = @user_profile[:user_id]
+      begin
+        @user_profile[:experiment_bucket_map][experiment_id] = {
+          variation_id: variation_id
+        }
+        @profile_updated = true
+        @logger.log(Logger::INFO, "Updated variation ID #{variation_id} of experiment ID #{experiment_id} for user '#{user_id}'.")
+      rescue => e
+        @logger.log(Logger::ERROR, "Error while updating user profile for user ID '#{user_id}': #{e}.")
+      end
+    end
+
+    def save_user_profile(error_handler = nil)
+      return unless @profile_updated && @user_profile_service
+
+      begin
+        @user_profile_service.save(@user_profile)
+        @logger.log(Logger::INFO, "Saved user profile for user '#{@user_profile[:user_id]}'.")
+      rescue => e
+        @logger.log(Logger::ERROR, "Failed to save user profile for user '#{@user_profile[:user_id]}': #{e}.")
+        error_handler&.handle_error(e)
+      end
+    end
+  end
+end

--- a/lib/optimizely/user_profile_tracker.rb
+++ b/lib/optimizely/user_profile_tracker.rb
@@ -23,8 +23,8 @@ module Optimizely
       begin
         @user_profile = @user_profile_service.lookup(@user_id) if @user_profile_service
       rescue => e
-        message = "Error while loading user profile in user profile tracker for user ID '#{@user_id}': #{e}."
-        reasons << e.message
+        message = "Error while looking up user profile for user ID '#{@user_id}': #{e}."
+        reasons << message
         @logger.log(Logger::ERROR, message)
         error_handler&.handle_error(e)
       end

--- a/lib/optimizely/user_profile_tracker.rb
+++ b/lib/optimizely/user_profile_tracker.rb
@@ -21,7 +21,7 @@ module Optimizely
       return if reasons.nil?
 
       begin
-        @user_profile = @user_profile_service.lookup(@user_id) || @user_profile
+        @user_profile = @user_profile_service.lookup(@user_id) if @user_profile_service
       rescue => e
         message = "Error while loading user profile in user profile tracker for user ID '#{@user_id}': #{e}."
         reasons << e.message

--- a/lib/optimizely/user_profile_tracker.rb
+++ b/lib/optimizely/user_profile_tracker.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'logger'
+
 module Optimizely
   class UserProfileTracker
     attr_reader :user_profile

--- a/lib/optimizely/user_profile_tracker.rb
+++ b/lib/optimizely/user_profile_tracker.rb
@@ -22,6 +22,12 @@ module Optimizely
 
       begin
         @user_profile = @user_profile_service.lookup(@user_id) if @user_profile_service
+        if @user_profile.nil?
+          @user_profile = {
+            user_id: @user_id,
+            experiment_bucket_map: {}
+          }
+        end
       rescue => e
         message = "Error while looking up user profile for user ID '#{@user_id}': #{e}."
         reasons << message

--- a/spec/decision_service_spec.rb
+++ b/spec/decision_service_spec.rb
@@ -73,7 +73,8 @@ describe Optimizely::DecisionService do
 
     it 'should return the correct variation ID for a given user ID and key of a running experiment' do
       user_context = project_instance.create_user_context('test_user')
-      variation_received, reasons = decision_service.get_variation(config, '111127', user_context)
+      user_profile_tracker = Optimizely::UserProfileTracker.new(user_context.user_id)
+      variation_received, reasons = decision_service.get_variation(config, '111127', user_context, user_profile_tracker)
       expect(variation_received).to eq('111128')
 
       expect(reasons).to eq([

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -4407,8 +4407,9 @@ describe 'Optimizely' do
           variation_to_return,
           Optimizely::DecisionService::DECISION_SOURCES['FEATURE_TEST']
         )
+        decision_list_to_return = [[decision_to_return, []]]
         allow(custom_project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
-        allow(custom_project_instance.decision_service).to receive(:get_variation_for_feature).and_return(decision_to_return)
+        allow(custom_project_instance.decision_service).to receive(:get_variations_for_feature_list).and_return(decision_list_to_return)
         user_context = custom_project_instance.create_user_context('user1')
         decision = custom_project_instance.decide(user_context, 'multi_variate_feature')
         expect(decision.as_json).to include(
@@ -4435,8 +4436,9 @@ describe 'Optimizely' do
           variation_to_return,
           Optimizely::DecisionService::DECISION_SOURCES['FEATURE_TEST']
         )
+        decision_list_to_return = [[decision_to_return, []]]
         allow(custom_project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
-        allow(custom_project_instance.decision_service).to receive(:get_variation_for_feature).and_return(decision_to_return)
+        allow(custom_project_instance.decision_service).to receive(:get_variations_for_feature_list).and_return(decision_list_to_return)
         user_context = custom_project_instance.create_user_context('user1')
         decision = custom_project_instance.decide(user_context, 'multi_variate_feature')
         expect(decision.as_json).to include(

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -3766,7 +3766,9 @@ describe 'Optimizely' do
           variation_to_return,
           Optimizely::DecisionService::DECISION_SOURCES['FEATURE_TEST']
         )
-        allow(project_instance.decision_service).to receive(:get_variation_for_feature).and_return(decision_to_return)
+        decision_list_to_be_returned = []
+        decision_list_to_be_returned << [decision_to_return, []]
+        allow(project_instance.decision_service).to receive(:get_variations_for_feature_list).and_return(decision_list_to_be_returned)
         user_context = project_instance.create_user_context('user1')
         decision = project_instance.decide(user_context, 'multi_variate_feature')
         expect(decision.as_json).to include(
@@ -3807,7 +3809,9 @@ describe 'Optimizely' do
           variation_to_return,
           Optimizely::DecisionService::DECISION_SOURCES['ROLLOUT']
         )
-        allow(project_instance.decision_service).to receive(:get_variation_for_feature).and_return(decision_to_return)
+        decision_list_to_be_returned = []
+        decision_list_to_be_returned << [decision_to_return, []]
+        allow(project_instance.decision_service).to receive(:get_variations_for_feature_list).and_return(decision_list_to_be_returned)
         user_context = project_instance.create_user_context('user1')
         decision = project_instance.decide(user_context, 'multi_variate_feature')
 
@@ -3888,7 +3892,8 @@ describe 'Optimizely' do
           variation_to_return,
           Optimizely::DecisionService::DECISION_SOURCES['ROLLOUT']
         )
-        allow(project_instance.decision_service).to receive(:get_variation_for_feature).and_return(decision_to_return)
+        decision_list_to_return = [[decision_to_return, []]]
+        allow(project_instance.decision_service).to receive(:get_variations_for_feature_list).and_return(decision_list_to_return)
         user_context = project_instance.create_user_context('user1')
         decision = project_instance.decide(user_context, 'multi_variate_feature')
         expect(decision.as_json).to include(
@@ -4055,8 +4060,9 @@ describe 'Optimizely' do
             variation_to_return,
             Optimizely::DecisionService::DECISION_SOURCES['FEATURE_TEST']
           )
+          decision_list_to_be_returned = [[decision_to_return, []]]
           allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
-          allow(project_instance.decision_service).to receive(:get_variation_for_feature).and_return(decision_to_return)
+          allow(project_instance.decision_service).to receive(:get_variations_for_feature_list).and_return(decision_list_to_be_returned)
           user_context = project_instance.create_user_context('user1')
           decision = project_instance.decide(user_context, 'multi_variate_feature', [Optimizely::Decide::OptimizelyDecideOption::EXCLUDE_VARIABLES])
           expect(decision.as_json).to include(
@@ -4078,8 +4084,9 @@ describe 'Optimizely' do
             variation_to_return,
             Optimizely::DecisionService::DECISION_SOURCES['FEATURE_TEST']
           )
+          decision_list_to_return = [[decision_to_return, []]]
           allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
-          allow(project_instance.decision_service).to receive(:get_variation_for_feature).and_return(decision_to_return)
+          allow(project_instance.decision_service).to receive(:get_variations_for_feature_list).and_return(decision_list_to_return)
           user_context = project_instance.create_user_context('user1')
           decision = project_instance.decide(user_context, 'multi_variate_feature')
           expect(decision.as_json).to include(
@@ -4096,8 +4103,6 @@ describe 'Optimizely' do
 
       describe 'INCLUDE_REASONS' do
         it 'should include reasons when the option is set' do
-          expect(project_instance.notification_center).to receive(:send_notifications)
-            .once.with(Optimizely::NotificationCenter::NOTIFICATION_TYPES[:LOG_EVENT], any_args)
           expect(project_instance.notification_center).to receive(:send_notifications)
             .once.with(
               Optimizely::NotificationCenter::NOTIFICATION_TYPES[:DECISION],
@@ -4119,6 +4124,8 @@ describe 'Optimizely' do
               ],
               decision_event_dispatched: true
             )
+          expect(project_instance.notification_center).to receive(:send_notifications)
+            .once.with(Optimizely::NotificationCenter::NOTIFICATION_TYPES[:LOG_EVENT], any_args)
           allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
           user_context = project_instance.create_user_context('user1')
           decision = project_instance.decide(user_context, 'multi_variate_feature', [Optimizely::Decide::OptimizelyDecideOption::INCLUDE_REASONS])
@@ -4180,23 +4187,23 @@ describe 'Optimizely' do
           variation_to_return,
           Optimizely::DecisionService::DECISION_SOURCES['FEATURE_TEST']
         )
+        decision_list_to_return = [[decision_to_return, []]]
         allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
-        allow(project_instance.decision_service).to receive(:get_variation_for_feature).and_return(decision_to_return)
+        allow(project_instance.decision_service).to receive(:get_variations_for_feature_list).and_return(decision_list_to_return)
         user_context = project_instance.create_user_context('user1')
 
-        expect(project_instance.decision_service).to receive(:get_variation_for_feature)
+        expect(project_instance.decision_service).to receive(:get_variations_for_feature_list)
           .with(anything, anything, anything, []).once
         project_instance.decide(user_context, 'multi_variate_feature')
 
-        expect(project_instance.decision_service).to receive(:get_variation_for_feature)
+        expect(project_instance.decision_service).to receive(:get_variations_for_feature_list)
           .with(anything, anything, anything, [Optimizely::Decide::OptimizelyDecideOption::DISABLE_DECISION_EVENT]).once
         project_instance.decide(user_context, 'multi_variate_feature', [Optimizely::Decide::OptimizelyDecideOption::DISABLE_DECISION_EVENT])
 
-        expect(project_instance.decision_service).to receive(:get_variation_for_feature)
+        expect(project_instance.decision_service).to receive(:get_variations_for_feature_list)
           .with(anything, anything, anything, [
                   Optimizely::Decide::OptimizelyDecideOption::DISABLE_DECISION_EVENT,
                   Optimizely::Decide::OptimizelyDecideOption::EXCLUDE_VARIABLES,
-                  Optimizely::Decide::OptimizelyDecideOption::ENABLED_FLAGS_ONLY,
                   Optimizely::Decide::OptimizelyDecideOption::IGNORE_USER_PROFILE_SERVICE,
                   Optimizely::Decide::OptimizelyDecideOption::INCLUDE_REASONS,
                   Optimizely::Decide::OptimizelyDecideOption::EXCLUDE_VARIABLES

--- a/spec/user_profile_tracker_spec.rb
+++ b/spec/user_profile_tracker_spec.rb
@@ -39,9 +39,8 @@ RSpec.describe Optimizely::UserProfileTracker do
 
       reasons = []
       user_profile_tracker.load_user_profile(reasons)
-
-      expect(reasons).to include('lookup error')
-      expect(mock_logger).to have_received(:log).with(Logger::ERROR, "Error while loading user profile in user profile tracker for user ID 'test_user': lookup error.")
+      expect(reasons).to include("Error while looking up user profile for user ID 'test_user': lookup error.")
+      expect(mock_logger).to have_received(:log).with(Logger::ERROR, "Error while looking up user profile for user ID 'test_user': lookup error.")
     end
 
     it 'does nothing if reasons array is nil' do

--- a/spec/user_profile_tracker_spec.rb
+++ b/spec/user_profile_tracker_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Optimizely::UserProfileTracker do
     it 'loads the user profile from the service if provided' do
       expected_profile = {
         user_id: user_id,
-        experiment_bucket_map: { '111127' => { variation_id: '111128' } }
+        experiment_bucket_map: {'111127' => {variation_id: '111128'}}
       }
       allow(mock_user_profile_service).to receive(:lookup).with(user_id).and_return(expected_profile)
       user_profile_tracker.load_user_profile

--- a/spec/user_profile_tracker_spec.rb
+++ b/spec/user_profile_tracker_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rspec'
+
+RSpec.describe Optimizely::UserProfileTracker do
+  let(:user_id) { 'test_user' }
+  let(:mock_user_profile_service) { instance_double('UserProfileService') }
+  let(:mock_logger) { instance_double('Logger') }
+  let(:user_profile_tracker) { described_class.new(user_id, mock_user_profile_service, mock_logger) }
+
+  describe '#initialize' do
+    it 'initializes with a user ID and default values' do
+      tracker = described_class.new(user_id)
+      expect(tracker.user_profile[:user_id]).to eq(user_id)
+      expect(tracker.user_profile[:experiment_bucket_map]).to eq({})
+    end
+
+    it 'accepts a user profile service and logger' do
+      expect(user_profile_tracker.instance_variable_get(:@user_profile_service)).to eq(mock_user_profile_service)
+      expect(user_profile_tracker.instance_variable_get(:@logger)).to eq(mock_logger)
+    end
+  end
+
+  describe '#load_user_profile' do
+    it 'loads the user profile from the service if provided' do
+      expected_profile = {
+        user_id: user_id,
+        experiment_bucket_map: { '111127' => { variation_id: '111128' } }
+      }
+      allow(mock_user_profile_service).to receive(:lookup).with(user_id).and_return(expected_profile)
+      user_profile_tracker.load_user_profile
+      expect(user_profile_tracker.user_profile).to eq(expected_profile)
+    end
+
+    it 'handles errors during lookup and logs them' do
+      allow(mock_user_profile_service).to receive(:lookup).with(user_id).and_raise(StandardError.new('lookup error'))
+      allow(mock_logger).to receive(:log)
+
+      reasons = []
+      user_profile_tracker.load_user_profile(reasons)
+
+      expect(reasons).to include('lookup error')
+      expect(mock_logger).to have_received(:log).with(Logger::ERROR, "Error while loading user profile in user profile tracker for user ID 'test_user': lookup error.")
+    end
+
+    it 'does nothing if reasons array is nil' do
+      expect(mock_user_profile_service).not_to receive(:lookup)
+      user_profile_tracker.load_user_profile(nil)
+    end
+  end
+
+  describe '#update_user_profile' do
+    let(:experiment_id) { '111127' }
+    let(:variation_id) { '111128' }
+
+    before do
+      allow(mock_logger).to receive(:log)
+    end
+
+    it 'updates the experiment bucket map with the given experiment and variation IDs' do
+      user_profile_tracker.update_user_profile(experiment_id, variation_id)
+
+      # Verify the experiment and variation were added
+      expect(user_profile_tracker.user_profile[:experiment_bucket_map][experiment_id][:variation_id]).to eq(variation_id)
+      # Verify the profile_updated flag was set
+      expect(user_profile_tracker.instance_variable_get(:@profile_updated)).to eq(true)
+      # Verify a log message was recorded
+      expect(mock_logger).to have_received(:log).with(Logger::INFO, "Updated variation ID #{variation_id} of experiment ID #{experiment_id} for user 'test_user'.")
+    end
+  end
+
+  describe '#save_user_profile' do
+    it 'saves the user profile if updates were made and service is available' do
+      allow(mock_user_profile_service).to receive(:save)
+      allow(mock_logger).to receive(:log)
+
+      user_profile_tracker.update_user_profile('111127', '111128')
+      user_profile_tracker.save_user_profile
+
+      expect(mock_user_profile_service).to have_received(:save).with(user_profile_tracker.user_profile)
+      expect(mock_logger).to have_received(:log).with(Logger::INFO, "Saved user profile for user 'test_user'.")
+    end
+
+    it 'does not save the user profile if no updates were made' do
+      allow(mock_user_profile_service).to receive(:save)
+
+      user_profile_tracker.save_user_profile
+      expect(mock_user_profile_service).not_to have_received(:save)
+    end
+
+    it 'handles errors during save and logs them' do
+      allow(mock_user_profile_service).to receive(:save).and_raise(StandardError.new('save error'))
+      allow(mock_logger).to receive(:log)
+
+      user_profile_tracker.update_user_profile('111127', '111128')
+      user_profile_tracker.save_user_profile
+
+      expect(mock_logger).to have_received(:log).with(Logger::ERROR, "Failed to save user profile for user 'test_user': save error.")
+    end
+  end
+end


### PR DESCRIPTION
Summary
-------
- Currently, decideForKeys loops over the list of flags and calls decide for each, which in turn calls ups. So for decideForKeys, there is two calls per flag to UPS. This PR batches UPS calls when using decideForKeys.

Test plan
---------

- Existing tests are updated to work with the new change. New tests will be added for batching.

Issues
------

-  [FSSDK-10765](https://jira.sso.episerver.net/browse/FSSDK-10765)
