### PR TITLE
[FSSDK-11389] update: experiment_id and variation_id added to payloads

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -219,7 +219,7 @@ module Optimizely
       @notification_center.send_notifications(
         NotificationCenter::NOTIFICATION_TYPES[:DECISION],
         Helpers::Constants::DECISION_NOTIFICATION_TYPES['FLAG'],
-        user_id, (attributes || {}),
+        user_id, attributes || {},
         flag_key: flag_key,
         enabled: feature_enabled,
         variables: all_variables,
@@ -632,7 +632,7 @@ module Optimizely
       @notification_center.send_notifications(
         NotificationCenter::NOTIFICATION_TYPES[:DECISION],
         Helpers::Constants::DECISION_NOTIFICATION_TYPES['FEATURE'],
-        user_id, (attributes || {}),
+        user_id, attributes || {},
         feature_key: feature_flag_key,
         feature_enabled: feature_enabled,
         source: source_string,
@@ -860,7 +860,7 @@ module Optimizely
 
       @notification_center.send_notifications(
         NotificationCenter::NOTIFICATION_TYPES[:DECISION],
-        Helpers::Constants::DECISION_NOTIFICATION_TYPES['ALL_FEATURE_VARIABLES'], user_id, (attributes || {}),
+        Helpers::Constants::DECISION_NOTIFICATION_TYPES['ALL_FEATURE_VARIABLES'], user_id, attributes || {},
         feature_key: feature_flag_key,
         feature_enabled: feature_enabled,
         source: source_string,
@@ -1040,7 +1040,7 @@ module Optimizely
                                    end
       @notification_center.send_notifications(
         NotificationCenter::NOTIFICATION_TYPES[:DECISION],
-        decision_notification_type, user_id, (attributes || {}),
+        decision_notification_type, user_id, attributes || {},
         experiment_key: experiment_key,
         variation_key: variation_key
       )
@@ -1115,7 +1115,7 @@ module Optimizely
 
       @notification_center.send_notifications(
         NotificationCenter::NOTIFICATION_TYPES[:DECISION],
-        Helpers::Constants::DECISION_NOTIFICATION_TYPES['FEATURE_VARIABLE'], user_id, (attributes || {}),
+        Helpers::Constants::DECISION_NOTIFICATION_TYPES['FEATURE_VARIABLE'], user_id, attributes || {},
         feature_key: feature_flag_key,
         feature_enabled: feature_enabled,
         source: source_string,

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -185,12 +185,17 @@ module Optimizely
       feature_flag = config.get_feature_flag_from_key(flag_key)
       experiment = nil
       decision_source = Optimizely::DecisionService::DECISION_SOURCES['ROLLOUT']
+      experiment_id = nil
+      variation_id = nil
+
       # Send impression event if Decision came from a feature test and decide options doesn't include disableDecisionEvent
       if decision.is_a?(Optimizely::DecisionService::Decision)
         experiment = decision.experiment
         rule_key = experiment ? experiment['key'] : nil
+        experiment_id = experiment ? experiment['id'] : nil
         variation = decision['variation']
         variation_key = variation ? variation['key'] : nil
+        variation_id = variation ? variation['id'] : nil
         feature_enabled = variation ? variation['featureEnabled'] : false
         decision_source = decision.source
       end
@@ -221,7 +226,9 @@ module Optimizely
         variation_key: variation_key,
         rule_key: rule_key,
         reasons: should_include_reasons ? reasons : [],
-        decision_event_dispatched: decision_event_dispatched
+        decision_event_dispatched: decision_event_dispatched,
+        experiment_id: experiment_id,
+        variation_id: variation_id
       )
 
       OptimizelyDecision.new(

--- a/lib/optimizely/helpers/validator.rb
+++ b/lib/optimizely/helpers/validator.rb
@@ -122,11 +122,11 @@ module Optimizely
 
         return false unless variables.respond_to?(:each) && !variables.empty?
 
-        is_valid = true # rubocop:disable Lint/UselessAssignment
+        is_valid = true
         if variables.include? :user_id
           # Empty str is a valid user ID.
           unless variables[:user_id].is_a?(String)
-            is_valid = false # rubocop:disable Lint/UselessAssignment
+            is_valid = false
             logger.log(level, "#{Constants::INPUT_VARIABLES['USER_ID']} is invalid")
           end
           variables.delete :user_id

--- a/spec/optimizely_user_context_spec.rb
+++ b/spec/optimizely_user_context_spec.rb
@@ -251,7 +251,9 @@ describe 'Optimizely' do
           variation_key: '3324490562',
           rule_key: nil,
           reasons: [],
-          decision_event_dispatched: true
+          decision_event_dispatched: true,
+          experiment_id: nil,
+          variation_id: '3324490562'
         )
       user_context_obj = forced_decision_project_instance.create_user_context(user_id)
       context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, nil)
@@ -347,7 +349,9 @@ describe 'Optimizely' do
           variation_key: 'b',
           rule_key: 'exp_with_audience',
           reasons: ['Variation (b) is mapped to flag (feature_1), rule (exp_with_audience) and user (tester) in the forced decision map.'],
-          decision_event_dispatched: true
+          decision_event_dispatched: true,
+          experiment_id: '10390977673',
+          variation_id: '10416523121'
         )
       user_context_obj = Optimizely::OptimizelyUserContext.new(forced_decision_project_instance, user_id, original_attributes)
       context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, 'exp_with_audience')
@@ -464,7 +468,9 @@ describe 'Optimizely' do
           variation_key: '3324490562',
           rule_key: nil,
           reasons: [],
-          decision_event_dispatched: true
+          decision_event_dispatched: true,
+          experiment_id: nil,
+          variation_id: '3324490562'
         )
       user_context_obj = forced_decision_project_instance.create_user_context(user_id)
       context_with_flag = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(feature_key, nil)

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -2079,7 +2079,7 @@ describe 'Optimizely' do
     it 'should return only enabled feature flags keys' do
       # Sets all feature-flags keys with randomly assigned status
       features_keys = project_config.feature_flags.map do |item|
-        {key: (item['key']).to_s, value: [true, false].sample} # '[true, false].sample' generates random boolean
+        {key: item['key'].to_s, value: [true, false].sample} # '[true, false].sample' generates random boolean
       end
 
       enabled_features = features_keys.map { |x| x[:key] if x[:value] == true }.compact
@@ -3758,7 +3758,9 @@ describe 'Optimizely' do
             variation_key: 'Fred',
             rule_key: 'test_experiment_multivariate',
             reasons: [],
-            decision_event_dispatched: true
+            decision_event_dispatched: true,
+            experiment_id: experiment_to_return['id'],
+            variation_id: variation_to_return['id']
           )
         allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
         decision_to_return = Optimizely::DecisionService::Decision.new(
@@ -3801,7 +3803,9 @@ describe 'Optimizely' do
             variation_key: 'Fred',
             rule_key: 'test_experiment_multivariate',
             reasons: [],
-            decision_event_dispatched: true
+            decision_event_dispatched: true,
+            experiment_id: experiment_to_return['id'],
+            variation_id: variation_to_return['id']
           )
         allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
         decision_to_return = Optimizely::DecisionService::Decision.new(
@@ -3883,7 +3887,9 @@ describe 'Optimizely' do
             variation_key: 'Fred',
             rule_key: 'test_experiment_multivariate',
             reasons: [],
-            decision_event_dispatched: false
+            decision_event_dispatched: false,
+            experiment_id: experiment_to_return['id'],
+            variation_id: variation_to_return['id']
           )
         allow(project_config).to receive(:send_flag_decisions).and_return(false)
         allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
@@ -3921,7 +3927,9 @@ describe 'Optimizely' do
             variation_key: nil,
             rule_key: nil,
             reasons: [],
-            decision_event_dispatched: false
+            decision_event_dispatched: false,
+            experiment_id: nil,
+            variation_id: nil
           )
         allow(project_config).to receive(:send_flag_decisions).and_return(false)
         allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
@@ -3958,7 +3966,9 @@ describe 'Optimizely' do
             variation_key: nil,
             rule_key: nil,
             reasons: [],
-            decision_event_dispatched: true
+            decision_event_dispatched: true,
+            experiment_id: nil,
+            variation_id: nil
           )
         allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
         decision_to_return = nil
@@ -4122,7 +4132,9 @@ describe 'Optimizely' do
                 "The user 'user1' is not bucketed into any of the experiments on the feature 'multi_variate_feature'.",
                 "Feature flag 'multi_variate_feature' is not used in a rollout."
               ],
-              decision_event_dispatched: true
+              decision_event_dispatched: true,
+              experiment_id: nil,
+              variation_id: nil
             )
           expect(project_instance.notification_center).to receive(:send_notifications)
             .once.with(Optimizely::NotificationCenter::NOTIFICATION_TYPES[:LOG_EVENT], any_args)
@@ -4162,7 +4174,9 @@ describe 'Optimizely' do
               variation_key: nil,
               rule_key: nil,
               reasons: [],
-              decision_event_dispatched: true
+              decision_event_dispatched: true,
+              experiment_id: nil,
+              variation_id: nil
             )
           allow(project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
           user_context = project_instance.create_user_context('user1')
@@ -4481,7 +4495,9 @@ describe 'Optimizely' do
               "The user 'user1' is not bucketed into any of the experiments on the feature 'multi_variate_feature'.",
               "Feature flag 'multi_variate_feature' is not used in a rollout."
             ],
-            decision_event_dispatched: true
+            decision_event_dispatched: true,
+            experiment_id: nil,
+            variation_id: nil
           )
         allow(custom_project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
         user_context = custom_project_instance.create_user_context('user1')
@@ -4521,7 +4537,9 @@ describe 'Optimizely' do
             variation_key: nil,
             rule_key: nil,
             reasons: [],
-            decision_event_dispatched: true
+            decision_event_dispatched: true,
+            experiment_id: nil,
+            variation_id: nil
           )
         allow(custom_project_instance.event_dispatcher).to receive(:dispatch_event).with(instance_of(Optimizely::Event))
         user_context = custom_project_instance.create_user_context('user1')


### PR DESCRIPTION
**Summary**
----------

- Added `experiment_id` and `variation_id` to the decision notification listener payload in the Python SDK.
- Ensured that these IDs are included in all decision notifications sent via the notification center.
- Updated unit tests to validate the presence of `experiment_id` and `variation_id` in the payload.

**Why**
-------

To support data warehouse-native customers who rely on SDK notification listeners to send experiment data to their data warehouse, we need to include `experiment_id` and `variation_id` in the payload. This ensures that the stats engine can correctly compute experiment results based on warehouse data.

**Test Plan**
------------

- Modify existing or add unit tests to check for the presence of `experiment_id` and `variation_id` in the notification payload.
- Run all tests to confirm that the changes do not introduce regressions.

**Issues**
---------

- [FSSDK-11389](https://jira.sso.episerver.net/browse/FSSDK-11389)
