### PR TITLE
[FSSDK-11723] fix: rubocop failing on ruby 3.0.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,6 +39,7 @@ jobs:
         echo "Installing rubocop 1.78.0 for Ruby 3.0.0"
         bundle add rubocop --version 1.78.0 || true
         bundle install
+        bundle exec rubocop -A Gemfile || true
     - name: Run linting
       run: |
         bundle exec rubocop

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.0.1', '3.1.0', '3.2.0', '3.3.0' ]
+        ruby: [ '3.0.0', '3.1.0', '3.2.0', '3.3.0' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby }}
@@ -33,6 +33,12 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+    - name: Install rubocop 1.78.0 for Ruby 3.0.0
+      if: matrix.ruby == '3.0.0'
+      run: |
+        echo "Installing rubocop 1.78.0 for Ruby 3.0.0"
+        bundle add rubocop --version 1.78.0 || true
+        bundle install
     - name: Run linting
       run: |
         bundle exec rubocop

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.0.0', '3.1.0', '3.2.0', '3.3.0' ]
+        ruby: [ '3.0.1', '3.1.0', '3.2.0', '3.3.0' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby }}


### PR DESCRIPTION
## Summary
Running rubocop via Bundler is currently failing due to a version conflict between the tsort gem and Ruby 3.0.0.

## Test plan
The existing unit tests has to pass.

## Issues
[FSSDK-11723](https://jira.sso.episerver.net/browse/FSSDK-11723)
