### PR TITLE
[AI-FSSDK] [FSSDK-12418] Remove experiment type validation from config parsing

### DIFF
--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -214,8 +214,7 @@ module Optimizely
                   'type' => 'object'
                 },
                 'type' => {
-                  'type' => %w[string null],
-                  'enum' => EXPERIMENT_TYPES.values + [nil]
+                  'type' => %w[string null]
                 },
                 'holdouts' => {
                   'type' => 'array'

--- a/spec/config/datafile_project_config_spec.rb
+++ b/spec/config/datafile_project_config_spec.rb
@@ -1880,6 +1880,39 @@ describe Optimizely::DatafileProjectConfig do
       expect(experiment['type']).to be_nil
     end
 
+    it 'should accept experiments with unknown type values' do
+      datafile = build_datafile(
+        experiments: [
+          {
+            'id' => 'exp_unknown',
+            'key' => 'unknown_type_exp',
+            'status' => 'Running',
+            'forcedVariations' => {},
+            'layerId' => 'layer_1',
+            'audienceIds' => [],
+            'trafficAllocation' => [{'entityId' => 'var_1', 'endOfRange' => 5000}],
+            'variations' => [{'key' => 'var_1', 'id' => 'var_1', 'featureEnabled' => true}],
+            'type' => 'new_unknown_type'
+          }
+        ],
+        feature_flags: [
+          {
+            'id' => 'flag_1',
+            'key' => 'test_flag',
+            'experimentIds' => ['exp_unknown'],
+            'rolloutId' => '',
+            'variables' => []
+          }
+        ]
+      )
+
+      config = Optimizely::DatafileProjectConfig.new(JSON.dump(datafile), logger, error_handler)
+      expect(config).not_to be_nil
+      experiment = config.experiment_id_map['exp_unknown']
+      expect(experiment['type']).to eq('new_unknown_type')
+      expect(experiment['key']).to eq('unknown_type_exp')
+    end
+
     it 'should inject everyone else variation into feature_rollout experiments' do
       datafile = build_datafile(
         experiments: [


### PR DESCRIPTION
## Summary

Removes experiment type validation from config parsing to ensure forward compatibility. Previously, the JSON schema restricted experiment type values to a known enum, which would reject the entire datafile when new experiment types are added in the future.

## Changes

- Removed enum constraint on experiment type field in JSON schema validation
- Unknown experiment types are now silently accepted and stored as-is
- Added test verifying unknown experiment types are accepted during config parsing

## Jira Ticket
[FSSDK-12418](https://optimizely-ext.atlassian.net/browse/FSSDK-12418)

[FSSDK-12418]: https://optimizely-ext.atlassian.net/browse/FSSDK-12418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ