### PR TITLE
[AI-FSSDK] [FSSDK-12670] Block ODP identify event for single identifier

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -1018,13 +1018,13 @@ module Optimizely
       @odp_manager.send_event(type: type, action: action, identifiers: identifiers, data: data)
     end
 
-    def identify_user(user_id:)
+    def identify_user(identifiers:)
       unless is_valid
         @logger.log(Logger::ERROR, InvalidProjectConfigError.new('identify_user').message)
         return
       end
 
-      @odp_manager.identify_user(user_id: user_id)
+      @odp_manager.identify_user(identifiers: identifiers)
     end
 
     def fetch_qualified_segments(user_id:, options: [])

--- a/lib/optimizely/odp/odp_manager.rb
+++ b/lib/optimizely/odp/odp_manager.rb
@@ -103,6 +103,8 @@ module Optimizely
       end
 
       valid_identifiers = identifiers.select { |_k, v| v && !v.to_s.empty? }
+      # Identify requires 2+ identifiers to link (e.g., vuid + fs_user_id).
+      # A single identifier has no cross-reference value and generates unnecessary traffic.
       if valid_identifiers.length < 2
         @logger.log(Logger::DEBUG, 'ODP identify event is not dispatched (fewer than 2 valid identifiers).')
         return

--- a/lib/optimizely/odp/odp_manager.rb
+++ b/lib/optimizely/odp/odp_manager.rb
@@ -87,7 +87,7 @@ module Optimizely
       @segment_manager.fetch_qualified_segments(ODP_MANAGER_CONFIG[:KEY_FOR_USER_ID], user_id, options)
     end
 
-    def identify_user(user_id:)
+    def identify_user(identifiers:)
       unless @enabled
         @logger.log(Logger::DEBUG, 'ODP identify event is not dispatched (ODP disabled).')
         return
@@ -102,10 +102,16 @@ module Optimizely
         return
       end
 
+      valid_identifiers = identifiers.select { |_k, v| v && !v.to_s.empty? }
+      if valid_identifiers.length < 2
+        @logger.log(Logger::DEBUG, 'ODP identify event is not dispatched (only one identifier provided).')
+        return
+      end
+
       @event_manager.send_event(
         type: ODP_MANAGER_CONFIG[:EVENT_TYPE],
         action: 'identified',
-        identifiers: {ODP_MANAGER_CONFIG[:KEY_FOR_USER_ID] => user_id},
+        identifiers: valid_identifiers,
         data: {}
       )
     end

--- a/lib/optimizely/odp/odp_manager.rb
+++ b/lib/optimizely/odp/odp_manager.rb
@@ -104,7 +104,7 @@ module Optimizely
 
       valid_identifiers = identifiers.select { |_k, v| v && !v.to_s.empty? }
       if valid_identifiers.length < 2
-        @logger.log(Logger::DEBUG, 'ODP identify event is not dispatched (only one identifier provided).')
+        @logger.log(Logger::DEBUG, 'ODP identify event is not dispatched (fewer than 2 valid identifiers).')
         return
       end
 

--- a/lib/optimizely/optimizely_user_context.rb
+++ b/lib/optimizely/optimizely_user_context.rb
@@ -17,6 +17,7 @@
 #
 
 require 'json'
+require_relative 'helpers/constants'
 
 module Optimizely
   class OptimizelyUserContext
@@ -36,7 +37,10 @@ module Optimizely
       @forced_decisions = {}
       @qualified_segments = nil
 
-      @optimizely_client&.identify_user(user_id: user_id) if identify
+      if identify
+        identifiers = {Optimizely::Helpers::Constants::ODP_MANAGER_CONFIG[:KEY_FOR_USER_ID] => user_id}
+        @optimizely_client&.identify_user(identifiers: identifiers)
+      end
     end
 
     def clone

--- a/lib/optimizely/optimizely_user_context.rb
+++ b/lib/optimizely/optimizely_user_context.rb
@@ -37,10 +37,10 @@ module Optimizely
       @forced_decisions = {}
       @qualified_segments = nil
 
-      if identify
-        identifiers = {Optimizely::Helpers::Constants::ODP_MANAGER_CONFIG[:KEY_FOR_USER_ID] => user_id}
-        @optimizely_client&.identify_user(identifiers: identifiers)
-      end
+      return unless identify
+
+      identifiers = {Optimizely::Helpers::Constants::ODP_MANAGER_CONFIG[:KEY_FOR_USER_ID] => user_id}
+      @optimizely_client&.identify_user(identifiers: identifiers)
     end
 
     def clone

--- a/spec/odp/odp_manager_spec.rb
+++ b/spec/odp/odp_manager_spec.rb
@@ -218,10 +218,11 @@ describe Optimizely::OdpManager do
   end
 
   describe '#identify_user' do
-    it 'should send event' do
+    it 'should send event when multiple identifiers provided' do
       allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
       event_manager = Optimizely::OdpEventManager.new
-      event = Optimizely::OdpEvent.new(type: 'fullstack', action: 'identified', identifiers: {user_key => user_value}, data: {})
+      identifiers = {user_key => user_value, 'email' => 'test@example.com'}
+      event = Optimizely::OdpEvent.new(type: 'fullstack', action: 'identified', identifiers: identifiers, data: {})
       expect(spy_logger).not_to receive(:log).with(Logger::ERROR, anything)
 
       expect(event_manager.api_manager)
@@ -233,7 +234,48 @@ describe Optimizely::OdpManager do
       manager = Optimizely::OdpManager.new(disable: false, event_manager: event_manager, logger: spy_logger)
       manager.update_odp_config(api_key, api_host, segments_to_check)
 
-      manager.identify_user(user_id: user_value)
+      manager.identify_user(identifiers: identifiers)
+
+      manager.stop!
+    end
+
+    it 'should not send event when only one identifier provided' do
+      expect(spy_logger).to receive(:log).with(Logger::DEBUG, 'ODP identify event is not dispatched (only one identifier provided).')
+
+      manager = Optimizely::OdpManager.new(disable: false, logger: spy_logger)
+      manager.update_odp_config(api_key, api_host, segments_to_check)
+      manager.identify_user(identifiers: {user_key => user_value})
+
+      manager.stop!
+    end
+
+    it 'should not count empty or nil identifier values' do
+      expect(spy_logger).to receive(:log).with(Logger::DEBUG, 'ODP identify event is not dispatched (only one identifier provided).')
+
+      manager = Optimizely::OdpManager.new(disable: false, logger: spy_logger)
+      manager.update_odp_config(api_key, api_host, segments_to_check)
+      manager.identify_user(identifiers: {user_key => user_value, 'email' => '', 'phone' => nil})
+
+      manager.stop!
+    end
+
+    it 'should send event with all valid identifiers when some are empty' do
+      allow(SecureRandom).to receive(:uuid).and_return(test_uuid)
+      event_manager = Optimizely::OdpEventManager.new
+      valid_identifiers = {user_key => user_value, 'email' => 'test@example.com'}
+      event = Optimizely::OdpEvent.new(type: 'fullstack', action: 'identified', identifiers: valid_identifiers, data: {})
+      expect(spy_logger).not_to receive(:log).with(Logger::ERROR, anything)
+
+      expect(event_manager.api_manager)
+        .to receive(:send_odp_events)
+        .once
+        .with(api_key, api_host, [event])
+        .and_return(false)
+
+      manager = Optimizely::OdpManager.new(disable: false, event_manager: event_manager, logger: spy_logger)
+      manager.update_odp_config(api_key, api_host, segments_to_check)
+
+      manager.identify_user(identifiers: {user_key => user_value, 'email' => 'test@example.com', 'phone' => ''})
 
       manager.stop!
     end
@@ -243,7 +285,7 @@ describe Optimizely::OdpManager do
       expect(spy_logger).to receive(:log).with(Logger::DEBUG, 'ODP identify event is not dispatched (ODP disabled).')
 
       manager = Optimizely::OdpManager.new(disable: true, logger: spy_logger)
-      manager.identify_user(user_id: user_value)
+      manager.identify_user(identifiers: {user_key => user_value, 'email' => 'test@example.com'})
 
       manager.stop!
     end
@@ -253,7 +295,7 @@ describe Optimizely::OdpManager do
       expect(spy_logger).to receive(:log).with(Logger::DEBUG, 'ODP identify event is not dispatched (ODP not integrated).')
       manager = Optimizely::OdpManager.new(disable: false, logger: spy_logger)
       manager.update_odp_config(nil, nil, [])
-      manager.identify_user(user_id: user_value)
+      manager.identify_user(identifiers: {user_key => user_value, 'email' => 'test@example.com'})
 
       manager.stop!
     end
@@ -263,7 +305,7 @@ describe Optimizely::OdpManager do
       expect(spy_logger).to receive(:log).with(Logger::DEBUG, 'ODP identify event is not dispatched (datafile not ready).')
 
       manager = Optimizely::OdpManager.new(disable: false, logger: spy_logger)
-      manager.identify_user(user_id: user_value)
+      manager.identify_user(identifiers: {user_key => user_value, 'email' => 'test@example.com'})
 
       manager.stop!
     end

--- a/spec/odp/odp_manager_spec.rb
+++ b/spec/odp/odp_manager_spec.rb
@@ -239,8 +239,8 @@ describe Optimizely::OdpManager do
       manager.stop!
     end
 
-    it 'should not send event when only one identifier provided' do
-      expect(spy_logger).to receive(:log).with(Logger::DEBUG, 'ODP identify event is not dispatched (only one identifier provided).')
+    it 'should not send event when fewer than 2 valid identifiers' do
+      expect(spy_logger).to receive(:log).with(Logger::DEBUG, 'ODP identify event is not dispatched (fewer than 2 valid identifiers).')
 
       manager = Optimizely::OdpManager.new(disable: false, logger: spy_logger)
       manager.update_odp_config(api_key, api_host, segments_to_check)
@@ -250,7 +250,7 @@ describe Optimizely::OdpManager do
     end
 
     it 'should not count empty or nil identifier values' do
-      expect(spy_logger).to receive(:log).with(Logger::DEBUG, 'ODP identify event is not dispatched (only one identifier provided).')
+      expect(spy_logger).to receive(:log).with(Logger::DEBUG, 'ODP identify event is not dispatched (fewer than 2 valid identifiers).')
 
       manager = Optimizely::OdpManager.new(disable: false, logger: spy_logger)
       manager.update_odp_config(api_key, api_host, segments_to_check)

--- a/spec/optimizely_user_context_spec.rb
+++ b/spec/optimizely_user_context_spec.rb
@@ -907,7 +907,7 @@ describe 'Optimizely' do
   it 'should send identify event when user context created' do
     stub_request(:post, 'https://api.zaius.com/v3/graphql').to_return(status: 200, body: good_response_data.to_json)
     stub_request(:post, 'https://api.zaius.com/v3/events').to_return(status: 200)
-    expect(integration_project_instance.odp_manager).to receive(:identify_user).with({user_id: 'tester'})
+    expect(integration_project_instance.odp_manager).to receive(:identify_user).with({identifiers: {'fs_user_id' => 'tester'}})
     Optimizely::OptimizelyUserContext.new(integration_project_instance, 'tester', {})
 
     integration_project_instance.close
@@ -915,7 +915,7 @@ describe 'Optimizely' do
 
   it 'should skip identify with decisions' do
     stub_request(:post, impression_log_url)
-    expect(integration_project_instance.odp_manager).to receive(:identify_user).with({user_id: 'tester'})
+    expect(integration_project_instance.odp_manager).to receive(:identify_user).with({identifiers: {'fs_user_id' => 'tester'}})
     expect(spy_logger).not_to receive(:log).with(Logger::ERROR, anything)
 
     user_context = Optimizely::OptimizelyUserContext.new(integration_project_instance, 'tester', {})

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -226,7 +226,7 @@ describe 'Optimizely' do
 
     it 'should send identify event when called with odp enabled' do
       project = Optimizely::Project.new(datafile: config_body_integrations_JSON, logger: spy_logger)
-      expect(project.odp_manager).to receive(:identify_user).with({user_id: 'tester'})
+      expect(project.odp_manager).to receive(:identify_user).with({identifiers: {'fs_user_id' => 'tester'}})
       project.create_user_context('tester')
 
       project.close


### PR DESCRIPTION
## Summary

Fixes ODP identify event to only send when multiple valid identifiers exist. Previously, the SDK always sent an identify event when creating a user context, even with just a single `fs_user_id`. This wastes network calls and pollutes ODP identity graphs with single-identifier records that provide no linking value.

## Changes
- Changed `identify_user` method signature across the identify chain to accept an `identifiers` hash instead of a single `user_id` keyword argument
- Added identifier count check in `OdpManager#identify_user` to skip sending when fewer than 2 valid identifiers are present
- Filters out identifiers with nil or empty string values before counting
- Added debug-level logging when the identify event is skipped due to single identifier
- Updated `OptimizelyUserContext` to construct identifiers hash using the `KEY_FOR_USER_ID` constant
- Updated existing tests and added new tests for single-identifier blocking and empty-value filtering

## Jira Ticket
[FSSDK-12670](https://optimizely-ext.atlassian.net/browse/FSSDK-12670)

## Notes
- Reference implementation: Python SDK PR #513

[FSSDK-12670]: https://optimizely-ext.atlassian.net/browse/FSSDK-12670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ