### PR TITLE
[FSSDK-12870] preparing release for v5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Optimizely Ruby SDK Changelog
 
+## 5.4.0
+July 8, 2026
+
+### New Features
+
+**Local Holdouts**: Added support for Local Holdouts, enabling holdout experiments
+to be scoped to specific feature flags rather than applied globally.
+Local Holdouts let you measure the true incremental impact of individual features
+by holding out a subset of users from specific rollouts while still serving them other experiences.
+See [Holdouts docs](https://support.optimizely.com/hc/en-us/articles/38941939408269-Global-holdouts) for more information.
+
+- Add local holdouts support with includedRules field ([#398](https://github.com/optimizely/ruby-sdk/pull/398))
+- Add localHoldouts datafile section for backward compatibility ([#400](https://github.com/optimizely/ruby-sdk/pull/400))
+
+### Bug Fixes
+- Use attribute id instead of key for CMAB prediction requests ([#402](https://github.com/optimizely/ruby-sdk/pull/402))
+- Normalize decision event campaign_id, variation_id, and entity_id ([#401](https://github.com/optimizely/ruby-sdk/pull/401))
+- Block ODP identify event for single identifier ([#399](https://github.com/optimizely/ruby-sdk/pull/399))
+
 ## 5.3.0
 May 4, 2026
 

--- a/lib/optimizely/version.rb
+++ b/lib/optimizely/version.rb
@@ -17,5 +17,5 @@
 #
 module Optimizely
   CLIENT_ENGINE = 'ruby-sdk'
-  VERSION = '5.3.0'
+  VERSION = '5.4.0'
 end


### PR DESCRIPTION
## Summary

Prepare for release v5.4.0

## Release Details
- Version Bump: v5.3.0 → v5.4.0 (minor)

## Issues
- [FSSDK-12870](https://optimizely-ext.atlassian.net/browse/FSSDK-12870)


[FSSDK-12870]: https://optimizely-ext.atlassian.net/browse/FSSDK-12870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ