### PR TITLE
[AI-FSSDK] [FSSDK-12735] Add holdout exclusion logic for Targeted Delivery rules

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -239,6 +239,7 @@ module Optimizely
           user_id,
           attributes
         )
+        decision_event_dispatched = true
       end
 
       # Generate all variables map if decide options doesn't include excludeVariables

--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -193,7 +193,7 @@ module Optimizely
       OptimizelyUserContext.new(self, user_id, attributes)
     end
 
-    def create_optimizely_decision(user_context, flag_key, decision, reasons, decide_options, config)
+    def create_optimizely_decision(user_context, flag_key, decision, reasons, decide_options, config, holdout_decision = nil)
       # Create Optimizely Decision Result.
       user_id = user_context.user_id
       attributes = user_context.user_attributes
@@ -223,6 +223,22 @@ module Optimizely
       if !decide_options.include?(OptimizelyDecideOption::DISABLE_DECISION_EVENT) && (decision_source == Optimizely::DecisionService::DECISION_SOURCES['FEATURE_TEST'] || decision_source == Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'] || config.send_flag_decisions)
         send_impression(config, experiment, variation_key || '', flag_key, rule_key || '', feature_enabled, decision_source, user_id, attributes, decision&.cmab_uuid)
         decision_event_dispatched = true
+      end
+
+      if holdout_decision && !decide_options.include?(OptimizelyDecideOption::DISABLE_DECISION_EVENT) && decision_source != Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT']
+        holdout_experiment = holdout_decision.experiment
+        holdout_variation = holdout_decision.variation
+        send_impression(
+          config,
+          holdout_experiment,
+          holdout_variation ? holdout_variation['key'] : '',
+          flag_key,
+          holdout_experiment ? holdout_experiment['key'] : '',
+          holdout_variation ? holdout_variation['featureEnabled'] : false,
+          Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'],
+          user_id,
+          attributes
+        )
       end
 
       # Generate all variables map if decide options doesn't include excludeVariables
@@ -377,6 +393,7 @@ module Optimizely
       end
       decision_list = @decision_service.get_variations_for_feature_list(config, flags_without_forced_decision, user_context, decide_options)
 
+      holdout_decisions = {}
       flags_without_forced_decision.each_with_index do |flag, i|
         decision = decision_list[i].decision
         reasons = decision_list[i].reasons
@@ -390,6 +407,8 @@ module Optimizely
           next
         end
         flag_decisions[flag_key] = decision
+        holdout_decision = decision_list[i].holdout_decision
+        holdout_decisions[flag_key] = holdout_decision if holdout_decision
         decision_reasons_dict[flag_key] ||= []
         decision_reasons_dict[flag_key].push(*reasons)
       end
@@ -402,7 +421,8 @@ module Optimizely
           flag_decision,
           decision_reasons,
           decide_options,
-          config
+          config,
+          holdout_decisions[key]
         )
 
         enabled_flags_only_missing = !decide_options.include?(OptimizelyDecideOption::ENABLED_FLAGS_ONLY)

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -437,14 +437,12 @@ module Optimizely
 
       # Step 2: Global holdout check (when excludeTargetedDeliveries is true, TD rules skip the holdout)
       if global_holdout_decision
-        if rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
-          return VariationResult.new(nil, false, reasons, nil, global_holdout_decision)
-        else
-          holdout_key = global_holdout_decision.experiment ? global_holdout_decision.experiment['key'] : 'unknown'
-          message = "Holdout '#{holdout_key}' has excludeTargetedDeliveries enabled, continuing to rollout evaluation."
-          @logger.log(Logger::INFO, message)
-          reasons.push(message)
-        end
+        return VariationResult.new(nil, false, reasons, nil, global_holdout_decision) if rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
+
+        holdout_key = global_holdout_decision.experiment ? global_holdout_decision.experiment['key'] : 'unknown'
+        message = "Holdout '#{holdout_key}' has excludeTargetedDeliveries enabled, continuing to rollout evaluation."
+        @logger.log(Logger::INFO, message)
+        reasons.push(message)
       end
 
       # Step 3: Local holdout check
@@ -477,14 +475,12 @@ module Optimizely
 
       # Step 2: Global holdout check
       if global_holdout_decision
-        if rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
-          return [global_holdout_decision, nil, skip_to_everyone_else, reasons]
-        else
-          holdout_key = global_holdout_decision.experiment ? global_holdout_decision.experiment['key'] : 'unknown'
-          message = "Holdout '#{holdout_key}' has excludeTargetedDeliveries enabled, continuing to rollout evaluation."
-          @logger.log(Logger::INFO, message)
-          reasons.push(message)
-        end
+        return [global_holdout_decision, nil, skip_to_everyone_else, reasons] if rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
+
+        holdout_key = global_holdout_decision.experiment ? global_holdout_decision.experiment['key'] : 'unknown'
+        message = "Holdout '#{holdout_key}' has excludeTargetedDeliveries enabled, continuing to rollout evaluation."
+        @logger.log(Logger::INFO, message)
+        reasons.push(message)
       end
 
       # Step 3: Local holdout check

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -334,6 +334,17 @@ module Optimizely
     end
 
     def get_variation_for_feature_experiment(project_config, feature_flag, user_context, user_profile_tracker, decide_options = [], global_holdout_decision = nil)
+      # Gets the variation the user is bucketed into for the feature flag's experiment.
+      #
+      # project_config - project_config - Instance of ProjectConfig
+      # feature_flag - The feature flag the user wants to access
+      # user_context - Optimizely user context instance
+      # user_profile_tracker - Tracker for reading and updating user profile of the user
+      # decide_options - Array of decide options
+      # global_holdout_decision - Decision from global holdout when excludeTargetedDeliveries is true (nil otherwise)
+      #
+      # Returns a DecisionResult containing the decision (or nil if not bucketed),
+      # an error flag, and an array of decision reasons.
       decide_reasons = []
       user_id = user_context.user_id
       feature_flag_key = feature_flag['key']
@@ -385,6 +396,16 @@ module Optimizely
     end
 
     def get_variation_for_feature_rollout(project_config, feature_flag, user_context, global_holdout_decision = nil)
+      # Determine which variation the user is in for a given rollout.
+      # Returns the variation of the first experiment the user qualifies for.
+      #
+      # project_config - project_config - Instance of ProjectConfig
+      # feature_flag - The feature flag the user wants to access
+      # user_context - Optimizely user context instance
+      # global_holdout_decision - Decision from global holdout when excludeTargetedDeliveries is true (nil otherwise)
+      #
+      # Returns a DecisionResult containing the decision (or nil if not bucketed),
+      # an error flag, and an array of decision reasons.
       decide_reasons = []
 
       rollout_id = feature_flag['rolloutId']
@@ -427,6 +448,18 @@ module Optimizely
     end
 
     def get_variation_from_experiment_rule(project_config, flag_key, rule, user, user_profile_tracker, options = [], global_holdout_decision = nil)
+      # Determine which variation the user is in for a given experiment rule.
+      # Returns the variation from experiment rules.
+      #
+      # project_config - project_config - Instance of ProjectConfig
+      # flag_key - The feature flag the user wants to access
+      # rule - An experiment rule key
+      # user - Optimizely user context instance
+      # user_profile_tracker - Tracker for reading and updating user profile of the user
+      # options - Array of decide options
+      # global_holdout_decision - Decision from global holdout when excludeTargetedDeliveries is true (nil otherwise)
+      #
+      # Returns variation_id and reasons
       reasons = []
 
       # Step 1: Forced decision check
@@ -463,6 +496,17 @@ module Optimizely
     end
 
     def get_variation_from_delivery_rule(project_config, flag_key, rules, rule_index, user_context, global_holdout_decision = nil)
+      # Determine which variation the user is in for a given delivery rule.
+      # Returns the variation from delivery rules.
+      #
+      # project_config - project_config - Instance of ProjectConfig
+      # flag_key - The feature flag key
+      # rules - Array of delivery rules
+      # rule_index - Index of the current rule
+      # user_context - Optimizely user context instance
+      # global_holdout_decision - Decision from global holdout when excludeTargetedDeliveries is true (nil otherwise)
+      #
+      # Returns variation_id, reasons, and skip_to_everyone_else flag
       reasons = []
       skip_to_everyone_else = false
       rule = rules[rule_index]

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -438,9 +438,7 @@ module Optimizely
       return VariationResult.new(nil, false, reasons, variation['id']) if variation
 
       # Step 2: Global holdout check (when excludeTargetedDeliveries is true, TD rules skip the holdout)
-      if global_holdout_decision && rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
-        return VariationResult.new(nil, false, reasons, nil, global_holdout_decision)
-      end
+      return VariationResult.new(nil, false, reasons, nil, global_holdout_decision) if global_holdout_decision && rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
 
       # Step 3: Local holdout check
       local_holdouts = project_config.get_holdouts_for_rule(rule['id'])
@@ -473,9 +471,7 @@ module Optimizely
       return [nil, variation, skip_to_everyone_else, reasons] if variation
 
       # Step 2: Global holdout check
-      if global_holdout_decision && rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
-        return [global_holdout_decision, nil, skip_to_everyone_else, reasons]
-      end
+      return [global_holdout_decision, nil, skip_to_everyone_else, reasons] if global_holdout_decision && rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
 
       # Step 3: Local holdout check
       local_holdouts = project_config.get_holdouts_for_rule(rule['id'])

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -219,14 +219,17 @@ module Optimizely
         end
       end
 
-      # Check if the feature flag has an experiment and the user is bucketed into that experiment
-      experiment_decision = get_variation_for_feature_experiment(project_config, feature_flag, user_context, user_profile_tracker, decide_options, exclude_td_holdout_decision)
-      reasons.push(*experiment_decision.reasons)
+      # When excludeTargetedDeliveries is active, skip experiment evaluation entirely
+      # and go straight to rollout
+      unless exclude_td_holdout_decision
+        experiment_decision = get_variation_for_feature_experiment(project_config, feature_flag, user_context, user_profile_tracker, decide_options)
+        reasons.push(*experiment_decision.reasons)
 
-      return DecisionResult.new(experiment_decision.decision, experiment_decision.error, reasons, exclude_td_holdout_decision) if experiment_decision.decision
+        return DecisionResult.new(experiment_decision.decision, experiment_decision.error, reasons) if experiment_decision.decision
 
-      # If there's an error (e.g., CMAB error), return immediately without falling back to rollout
-      return DecisionResult.new(nil, experiment_decision.error, reasons, exclude_td_holdout_decision) if experiment_decision.error
+        # If there's an error (e.g., CMAB error), return immediately without falling back to rollout
+        return DecisionResult.new(nil, experiment_decision.error, reasons) if experiment_decision.error
+      end
 
       # Check if the feature flag has a rollout and the user is bucketed into that rollout
       rollout_decision = get_variation_for_feature_rollout(project_config, feature_flag, user_context, exclude_td_holdout_decision)
@@ -468,14 +471,9 @@ module Optimizely
       reasons.push(*forced_reasons)
       return VariationResult.new(nil, false, reasons, variation['id']) if variation
 
-      # Step 2: Global holdout check (when excludeTargetedDeliveries is true, TD rules skip the holdout)
+      # Step 2: Global holdout check (when excludeTargetedDeliveries is true, all experiment rules are blocked)
       if global_holdout_decision
-        return VariationResult.new(nil, false, reasons, nil, global_holdout_decision) if rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
-
-        holdout_key = global_holdout_decision.experiment ? global_holdout_decision.experiment['key'] : 'unknown'
-        message = "Holdout '#{holdout_key}' has excludeTargetedDeliveries enabled, continuing to rollout evaluation."
-        @logger.log(Logger::INFO, message)
-        reasons.push(message)
+        return VariationResult.new(nil, false, reasons, nil, global_holdout_decision)
       end
 
       # Step 3: Local holdout check
@@ -517,15 +515,8 @@ module Optimizely
       reasons.push(*forced_reasons)
       return [nil, variation, skip_to_everyone_else, reasons] if variation
 
-      # Step 2: Global holdout check
-      if global_holdout_decision
-        return [global_holdout_decision, nil, skip_to_everyone_else, reasons] if rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
-
-        holdout_key = global_holdout_decision.experiment ? global_holdout_decision.experiment['key'] : 'unknown'
-        message = "Holdout '#{holdout_key}' has excludeTargetedDeliveries enabled, continuing to rollout evaluation."
-        @logger.log(Logger::INFO, message)
-        reasons.push(message)
-      end
+      # Step 2: Global holdout check (when excludeTargetedDeliveries is true, all rollout rules evaluate normally)
+      # No blocking here — ETD bypasses holdout for the entire rollout evaluation
 
       # Step 3: Local holdout check
       local_holdouts = project_config.get_holdouts_for_rule(rule['id'])

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -207,7 +207,7 @@ module Optimizely
         next unless holdout_decision.decision
 
         if holdout['exclude_targeted_deliveries'] == true
-          message = "The user '#{user_id}' is bucketed into holdout '#{holdout['key']}' for feature flag '#{feature_flag['key']}', but targeted deliveries are excluded."
+          message = "Holdout \"#{holdout['key']}\" has excludeTargetedDeliveries enabled, continuing to rollout evaluation."
           @logger.log(Logger::INFO, message)
           reasons.push(message)
           exclude_td_holdout_decision = holdout_decision.decision

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -206,7 +206,7 @@ module Optimizely
 
         next unless holdout_decision.decision
 
-        if holdout['excludeTargetedDeliveries'] == true
+        if holdout['exclude_targeted_deliveries'] == true
           message = "The user '#{user_id}' is bucketed into holdout '#{holdout['key']}' for feature flag '#{feature_flag['key']}', but targeted deliveries are excluded."
           @logger.log(Logger::INFO, message)
           reasons.push(message)

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -41,7 +41,7 @@ module Optimizely
     Decision = Struct.new(:experiment, :variation, :source, :cmab_uuid)
     CmabDecisionResult = Struct.new(:error, :result, :reasons)
     VariationResult = Struct.new(:cmab_uuid, :error, :reasons, :variation_id, :holdout_decision)
-    DecisionResult = Struct.new(:decision, :error, :reasons)
+    DecisionResult = Struct.new(:decision, :error, :reasons, :holdout_decision)
 
     DECISION_SOURCES = {
       'EXPERIMENT' => 'experiment',
@@ -223,10 +223,10 @@ module Optimizely
       experiment_decision = get_variation_for_feature_experiment(project_config, feature_flag, user_context, user_profile_tracker, decide_options, exclude_td_holdout_decision)
       reasons.push(*experiment_decision.reasons)
 
-      return DecisionResult.new(experiment_decision.decision, experiment_decision.error, reasons) if experiment_decision.decision
+      return DecisionResult.new(experiment_decision.decision, experiment_decision.error, reasons, exclude_td_holdout_decision) if experiment_decision.decision
 
       # If there's an error (e.g., CMAB error), return immediately without falling back to rollout
-      return DecisionResult.new(nil, experiment_decision.error, reasons) if experiment_decision.error
+      return DecisionResult.new(nil, experiment_decision.error, reasons, exclude_td_holdout_decision) if experiment_decision.error
 
       # Check if the feature flag has a rollout and the user is bucketed into that rollout
       rollout_decision = get_variation_for_feature_rollout(project_config, feature_flag, user_context, exclude_td_holdout_decision)
@@ -243,13 +243,11 @@ module Optimizely
           reasons.push(message)
         end
 
-        DecisionResult.new(rollout_decision.decision, rollout_decision.error, reasons)
+        DecisionResult.new(rollout_decision.decision, rollout_decision.error, reasons, exclude_td_holdout_decision)
       else
-        return DecisionResult.new(exclude_td_holdout_decision, false, reasons) if exclude_td_holdout_decision
-
         message = "The user '#{user_id}' is not bucketed into a rollout for feature flag '#{feature_flag['key']}'."
         @logger.log(Logger::INFO, message)
-        DecisionResult.new(nil, false, reasons)
+        DecisionResult.new(nil, false, reasons, exclude_td_holdout_decision)
       end
     end
 
@@ -443,8 +441,6 @@ module Optimizely
       # Step 3: Local holdout check
       local_holdouts = project_config.get_holdouts_for_rule(rule['id'])
       local_holdouts.each do |holdout|
-        next if holdout['excludeTargetedDeliveries'] == true && rule['type'] == Helpers::Constants::EXPERIMENT_TYPES['td']
-
         holdout_decision = get_variation_for_holdout(holdout, user, project_config)
         reasons.push(*holdout_decision.reasons)
         next unless holdout_decision.decision
@@ -476,8 +472,6 @@ module Optimizely
       # Step 3: Local holdout check
       local_holdouts = project_config.get_holdouts_for_rule(rule['id'])
       local_holdouts.each do |holdout|
-        next if holdout['excludeTargetedDeliveries'] == true && rule['type'] == Helpers::Constants::EXPERIMENT_TYPES['td']
-
         holdout_decision = get_variation_for_holdout(holdout, user_context, project_config)
         reasons.push(*holdout_decision.reasons)
         return [holdout_decision.decision, nil, skip_to_everyone_else, reasons] if holdout_decision.decision

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -211,6 +211,7 @@ module Optimizely
           @logger.log(Logger::INFO, message)
           reasons.push(message)
           exclude_td_holdout_decision = holdout_decision.decision
+          break
         else
           message = "The user '#{user_id}' is bucketed into holdout '#{holdout['key']}' for feature flag '#{feature_flag['key']}'."
           @logger.log(Logger::INFO, message)
@@ -232,7 +233,7 @@ module Optimizely
       end
 
       # Check if the feature flag has a rollout and the user is bucketed into that rollout
-      rollout_decision = get_variation_for_feature_rollout(project_config, feature_flag, user_context, exclude_td_holdout_decision)
+      rollout_decision = get_variation_for_feature_rollout(project_config, feature_flag, user_context)
       reasons.push(*rollout_decision.reasons)
 
       if rollout_decision.decision
@@ -336,7 +337,7 @@ module Optimizely
       decisions
     end
 
-    def get_variation_for_feature_experiment(project_config, feature_flag, user_context, user_profile_tracker, decide_options = [], global_holdout_decision = nil)
+    def get_variation_for_feature_experiment(project_config, feature_flag, user_context, user_profile_tracker, decide_options = [])
       # Gets the variation the user is bucketed into for the feature flag's experiment.
       #
       # project_config - project_config - Instance of ProjectConfig
@@ -344,7 +345,6 @@ module Optimizely
       # user_context - Optimizely user context instance
       # user_profile_tracker - Tracker for reading and updating user profile of the user
       # decide_options - Array of decide options
-      # global_holdout_decision - Decision from global holdout when excludeTargetedDeliveries is true (nil otherwise)
       #
       # Returns a DecisionResult containing the decision (or nil if not bucketed),
       # an error flag, and an array of decision reasons.
@@ -369,7 +369,7 @@ module Optimizely
         end
 
         experiment_id = experiment['id']
-        variation_result = get_variation_from_experiment_rule(project_config, feature_flag_key, experiment, user_context, user_profile_tracker, decide_options, global_holdout_decision)
+        variation_result = get_variation_from_experiment_rule(project_config, feature_flag_key, experiment, user_context, user_profile_tracker, decide_options)
         error = variation_result.error
         reasons_received = variation_result.reasons
         variation_id = variation_result.variation_id
@@ -379,7 +379,7 @@ module Optimizely
         # If there's an error, return immediately instead of falling back to next experiment
         return DecisionResult.new(nil, error, decide_reasons) if error
 
-        # If a global holdout decision was made, return it directly
+        # If a local holdout decision was made, return it directly
         return DecisionResult.new(variation_result.holdout_decision, false, decide_reasons) if variation_result.holdout_decision
 
         next unless variation_id
@@ -398,14 +398,13 @@ module Optimizely
       DecisionResult.new(nil, false, decide_reasons)
     end
 
-    def get_variation_for_feature_rollout(project_config, feature_flag, user_context, global_holdout_decision = nil)
+    def get_variation_for_feature_rollout(project_config, feature_flag, user_context)
       # Determine which variation the user is in for a given rollout.
       # Returns the variation of the first experiment the user qualifies for.
       #
       # project_config - project_config - Instance of ProjectConfig
       # feature_flag - The feature flag the user wants to access
       # user_context - Optimizely user context instance
-      # global_holdout_decision - Decision from global holdout when excludeTargetedDeliveries is true (nil otherwise)
       #
       # Returns a DecisionResult containing the decision (or nil if not bucketed),
       # an error flag, and an array of decision reasons.
@@ -433,7 +432,7 @@ module Optimizely
       index = 0
       rollout_rules = rollout['experiments']
       while index < rollout_rules.length
-        holdout_decision, variation, skip_to_everyone_else, reasons_received = get_variation_from_delivery_rule(project_config, feature_flag_key, rollout_rules, index, user_context, global_holdout_decision)
+        holdout_decision, variation, skip_to_everyone_else, reasons_received = get_variation_from_delivery_rule(project_config, feature_flag_key, rollout_rules, index, user_context)
         decide_reasons.push(*reasons_received)
 
         return DecisionResult.new(holdout_decision, false, decide_reasons) if holdout_decision
@@ -450,7 +449,7 @@ module Optimizely
       DecisionResult.new(nil, false, decide_reasons)
     end
 
-    def get_variation_from_experiment_rule(project_config, flag_key, rule, user, user_profile_tracker, options = [], global_holdout_decision = nil)
+    def get_variation_from_experiment_rule(project_config, flag_key, rule, user, user_profile_tracker, options = [])
       # Determine which variation the user is in for a given experiment rule.
       # Returns the variation from experiment rules.
       #
@@ -460,7 +459,6 @@ module Optimizely
       # user - Optimizely user context instance
       # user_profile_tracker - Tracker for reading and updating user profile of the user
       # options - Array of decide options
-      # global_holdout_decision - Decision from global holdout when excludeTargetedDeliveries is true (nil otherwise)
       #
       # Returns variation_id and reasons
       reasons = []
@@ -471,10 +469,7 @@ module Optimizely
       reasons.push(*forced_reasons)
       return VariationResult.new(nil, false, reasons, variation['id']) if variation
 
-      # Step 2: Global holdout check (when excludeTargetedDeliveries is true, all experiment rules are blocked)
-      return VariationResult.new(nil, false, reasons, nil, global_holdout_decision) if global_holdout_decision
-
-      # Step 3: Local holdout check
+      # Step 2: Local holdout check
       local_holdouts = project_config.get_holdouts_for_rule(rule['id'])
       local_holdouts.each do |holdout|
         holdout_decision = get_variation_for_holdout(holdout, user, project_config)
@@ -491,7 +486,7 @@ module Optimizely
       variation_result
     end
 
-    def get_variation_from_delivery_rule(project_config, flag_key, rules, rule_index, user_context, _global_holdout_decision = nil)
+    def get_variation_from_delivery_rule(project_config, flag_key, rules, rule_index, user_context)
       # Determine which variation the user is in for a given delivery rule.
       # Returns the variation from delivery rules.
       #
@@ -500,7 +495,6 @@ module Optimizely
       # rules - Array of delivery rules
       # rule_index - Index of the current rule
       # user_context - Optimizely user context instance
-      # global_holdout_decision - Decision from global holdout when excludeTargetedDeliveries is true (nil otherwise)
       #
       # Returns variation_id, reasons, and skip_to_everyone_else flag
       reasons = []
@@ -513,10 +507,7 @@ module Optimizely
       reasons.push(*forced_reasons)
       return [nil, variation, skip_to_everyone_else, reasons] if variation
 
-      # Step 2: Global holdout check (when excludeTargetedDeliveries is true, all rollout rules evaluate normally)
-      # No blocking here — ETD bypasses holdout for the entire rollout evaluation
-
-      # Step 3: Local holdout check
+      # Step 2: Local holdout check
       local_holdouts = project_config.get_holdouts_for_rule(rule['id'])
       local_holdouts.each do |holdout|
         holdout_decision = get_variation_for_holdout(holdout, user_context, project_config)

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -206,7 +206,7 @@ module Optimizely
 
         next unless holdout_decision.decision
 
-        if holdout['exclude_targeted_deliveries'] == true
+        if holdout['excludeTargetedDeliveries'] == true
           message = "Holdout \"#{holdout['key']}\" has excludeTargetedDeliveries enabled, continuing to rollout evaluation."
           @logger.log(Logger::INFO, message)
           reasons.push(message)

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2017-2022, Optimizely and contributors
+#    Copyright 2017-2022, 2026, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -198,6 +198,7 @@ module Optimizely
 
       # Check global holdouts first (flag level) — these apply to all rules across all flags
       holdouts = project_config.global_holdouts
+      exclude_td_holdout_decision = nil
 
       holdouts.each do |holdout|
         holdout_decision = get_variation_for_holdout(holdout, user_context, project_config)
@@ -205,14 +206,21 @@ module Optimizely
 
         next unless holdout_decision.decision
 
-        message = "The user '#{user_id}' is bucketed into holdout '#{holdout['key']}' for feature flag '#{feature_flag['key']}'."
-        @logger.log(Logger::INFO, message)
-        reasons.push(message)
-        return DecisionResult.new(holdout_decision.decision, false, reasons)
+        if holdout['excludeTargetedDeliveries'] == true
+          message = "The user '#{user_id}' is bucketed into holdout '#{holdout['key']}' for feature flag '#{feature_flag['key']}', but targeted deliveries are excluded."
+          @logger.log(Logger::INFO, message)
+          reasons.push(message)
+          exclude_td_holdout_decision = holdout_decision.decision
+        else
+          message = "The user '#{user_id}' is bucketed into holdout '#{holdout['key']}' for feature flag '#{feature_flag['key']}'."
+          @logger.log(Logger::INFO, message)
+          reasons.push(message)
+          return DecisionResult.new(holdout_decision.decision, false, reasons)
+        end
       end
 
       # Check if the feature flag has an experiment and the user is bucketed into that experiment
-      experiment_decision = get_variation_for_feature_experiment(project_config, feature_flag, user_context, user_profile_tracker, decide_options)
+      experiment_decision = get_variation_for_feature_experiment(project_config, feature_flag, user_context, user_profile_tracker, decide_options, exclude_td_holdout_decision)
       reasons.push(*experiment_decision.reasons)
 
       return DecisionResult.new(experiment_decision.decision, experiment_decision.error, reasons) if experiment_decision.decision
@@ -221,7 +229,7 @@ module Optimizely
       return DecisionResult.new(nil, experiment_decision.error, reasons) if experiment_decision.error
 
       # Check if the feature flag has a rollout and the user is bucketed into that rollout
-      rollout_decision = get_variation_for_feature_rollout(project_config, feature_flag, user_context)
+      rollout_decision = get_variation_for_feature_rollout(project_config, feature_flag, user_context, exclude_td_holdout_decision)
       reasons.push(*rollout_decision.reasons)
 
       if rollout_decision.decision
@@ -237,6 +245,8 @@ module Optimizely
 
         DecisionResult.new(rollout_decision.decision, rollout_decision.error, reasons)
       else
+        return DecisionResult.new(exclude_td_holdout_decision, false, reasons) if exclude_td_holdout_decision
+
         message = "The user '#{user_id}' is not bucketed into a rollout for feature flag '#{feature_flag['key']}'."
         @logger.log(Logger::INFO, message)
         DecisionResult.new(nil, false, reasons)
@@ -325,15 +335,7 @@ module Optimizely
       decisions
     end
 
-    def get_variation_for_feature_experiment(project_config, feature_flag, user_context, user_profile_tracker, decide_options = [])
-      # Gets the variation the user is bucketed into for the feature flag's experiment.
-      #
-      # project_config - project_config - Instance of ProjectConfig
-      # feature_flag - The feature flag the user wants to access
-      # user_context - Optimizely user context instance
-      #
-      # Returns a DecisionResult containing the decision (or nil if not bucketed),
-      # an error flag, and an array of decision reasons.
+    def get_variation_for_feature_experiment(project_config, feature_flag, user_context, user_profile_tracker, decide_options = [], global_holdout_decision = nil)
       decide_reasons = []
       user_id = user_context.user_id
       feature_flag_key = feature_flag['key']
@@ -355,7 +357,7 @@ module Optimizely
         end
 
         experiment_id = experiment['id']
-        variation_result = get_variation_from_experiment_rule(project_config, feature_flag_key, experiment, user_context, user_profile_tracker, decide_options)
+        variation_result = get_variation_from_experiment_rule(project_config, feature_flag_key, experiment, user_context, user_profile_tracker, decide_options, global_holdout_decision)
         error = variation_result.error
         reasons_received = variation_result.reasons
         variation_id = variation_result.variation_id
@@ -384,16 +386,7 @@ module Optimizely
       DecisionResult.new(nil, false, decide_reasons)
     end
 
-    def get_variation_for_feature_rollout(project_config, feature_flag, user_context)
-      # Determine which variation the user is in for a given rollout.
-      # Returns the variation of the first experiment the user qualifies for.
-      #
-      # project_config - project_config - Instance of ProjectConfig
-      # feature_flag - The feature flag the user wants to access
-      # user_context - Optimizely user context instance
-      #
-      # Returns a DecisionResult containing the decision (or nil if not bucketed),
-      # an error flag, and an array of decision reasons.
+    def get_variation_for_feature_rollout(project_config, feature_flag, user_context, global_holdout_decision = nil)
       decide_reasons = []
 
       rollout_id = feature_flag['rolloutId']
@@ -418,7 +411,7 @@ module Optimizely
       index = 0
       rollout_rules = rollout['experiments']
       while index < rollout_rules.length
-        holdout_decision, variation, skip_to_everyone_else, reasons_received = get_variation_from_delivery_rule(project_config, feature_flag_key, rollout_rules, index, user_context)
+        holdout_decision, variation, skip_to_everyone_else, reasons_received = get_variation_from_delivery_rule(project_config, feature_flag_key, rollout_rules, index, user_context, global_holdout_decision)
         decide_reasons.push(*reasons_received)
 
         return DecisionResult.new(holdout_decision, false, decide_reasons) if holdout_decision
@@ -435,16 +428,7 @@ module Optimizely
       DecisionResult.new(nil, false, decide_reasons)
     end
 
-    def get_variation_from_experiment_rule(project_config, flag_key, rule, user, user_profile_tracker, options = [])
-      # Determine which variation the user is in for a given rollout.
-      # Returns the variation from experiment rules.
-      #
-      # project_config - project_config - Instance of ProjectConfig
-      # flag_key - The feature flag the user wants to access
-      # rule - An experiment rule key
-      # user - Optimizely user context instance
-      #
-      # Returns variation_id and reasons
+    def get_variation_from_experiment_rule(project_config, flag_key, rule, user, user_profile_tracker, options = [], global_holdout_decision = nil)
       reasons = []
 
       # Step 1: Forced decision check
@@ -453,9 +437,16 @@ module Optimizely
       reasons.push(*forced_reasons)
       return VariationResult.new(nil, false, reasons, variation['id']) if variation
 
-      # Step 2: Local holdout check
+      # Step 2: Global holdout check (when excludeTargetedDeliveries is true, TD rules skip the holdout)
+      if global_holdout_decision && rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
+        return VariationResult.new(nil, false, reasons, nil, global_holdout_decision)
+      end
+
+      # Step 3: Local holdout check
       local_holdouts = project_config.get_holdouts_for_rule(rule['id'])
       local_holdouts.each do |holdout|
+        next if holdout['excludeTargetedDeliveries'] == true && rule['type'] == Helpers::Constants::EXPERIMENT_TYPES['td']
+
         holdout_decision = get_variation_for_holdout(holdout, user, project_config)
         reasons.push(*holdout_decision.reasons)
         next unless holdout_decision.decision
@@ -464,22 +455,13 @@ module Optimizely
         return VariationResult.new(nil, false, reasons, holdout_variation['id'], holdout_decision.decision)
       end
 
-      # Step 3: Regular rule evaluation
+      # Step 4: Regular rule evaluation
       variation_result = get_variation(project_config, rule['id'], user, user_profile_tracker, options)
       variation_result.reasons = reasons + variation_result.reasons
       variation_result
     end
 
-    def get_variation_from_delivery_rule(project_config, flag_key, rules, rule_index, user_context)
-      # Determine which variation the user is in for a given rollout.
-      # Returns the variation from delivery rules.
-      #
-      # project_config - project_config - Instance of ProjectConfig
-      # flag_key - The feature flag the user wants to access
-      # rule - An experiment rule key
-      # user_context - Optimizely user context instance
-      #
-      # Returns [holdout_decision, variation, skip_to_everyone_else, reasons]
+    def get_variation_from_delivery_rule(project_config, flag_key, rules, rule_index, user_context, global_holdout_decision = nil)
       reasons = []
       skip_to_everyone_else = false
       rule = rules[rule_index]
@@ -490,15 +472,22 @@ module Optimizely
       reasons.push(*forced_reasons)
       return [nil, variation, skip_to_everyone_else, reasons] if variation
 
-      # Step 2: Local holdout check
+      # Step 2: Global holdout check
+      if global_holdout_decision && rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
+        return [global_holdout_decision, nil, skip_to_everyone_else, reasons]
+      end
+
+      # Step 3: Local holdout check
       local_holdouts = project_config.get_holdouts_for_rule(rule['id'])
       local_holdouts.each do |holdout|
+        next if holdout['excludeTargetedDeliveries'] == true && rule['type'] == Helpers::Constants::EXPERIMENT_TYPES['td']
+
         holdout_decision = get_variation_for_holdout(holdout, user_context, project_config)
         reasons.push(*holdout_decision.reasons)
         return [holdout_decision.decision, nil, skip_to_everyone_else, reasons] if holdout_decision.decision
       end
 
-      # Step 3: Regular rule evaluation
+      # Step 4: Regular rule evaluation
       user_id = user_context.user_id
       attributes = user_context.user_attributes
       bucketing_id, bucketing_id_reasons = get_bucketing_id(user_id, attributes)

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -472,9 +472,7 @@ module Optimizely
       return VariationResult.new(nil, false, reasons, variation['id']) if variation
 
       # Step 2: Global holdout check (when excludeTargetedDeliveries is true, all experiment rules are blocked)
-      if global_holdout_decision
-        return VariationResult.new(nil, false, reasons, nil, global_holdout_decision)
-      end
+      return VariationResult.new(nil, false, reasons, nil, global_holdout_decision) if global_holdout_decision
 
       # Step 3: Local holdout check
       local_holdouts = project_config.get_holdouts_for_rule(rule['id'])
@@ -493,7 +491,7 @@ module Optimizely
       variation_result
     end
 
-    def get_variation_from_delivery_rule(project_config, flag_key, rules, rule_index, user_context, global_holdout_decision = nil)
+    def get_variation_from_delivery_rule(project_config, flag_key, rules, rule_index, user_context, _global_holdout_decision = nil)
       # Determine which variation the user is in for a given delivery rule.
       # Returns the variation from delivery rules.
       #

--- a/lib/optimizely/decision_service.rb
+++ b/lib/optimizely/decision_service.rb
@@ -436,7 +436,16 @@ module Optimizely
       return VariationResult.new(nil, false, reasons, variation['id']) if variation
 
       # Step 2: Global holdout check (when excludeTargetedDeliveries is true, TD rules skip the holdout)
-      return VariationResult.new(nil, false, reasons, nil, global_holdout_decision) if global_holdout_decision && rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
+      if global_holdout_decision
+        if rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
+          return VariationResult.new(nil, false, reasons, nil, global_holdout_decision)
+        else
+          holdout_key = global_holdout_decision.experiment ? global_holdout_decision.experiment['key'] : 'unknown'
+          message = "Holdout '#{holdout_key}' has excludeTargetedDeliveries enabled, continuing to rollout evaluation."
+          @logger.log(Logger::INFO, message)
+          reasons.push(message)
+        end
+      end
 
       # Step 3: Local holdout check
       local_holdouts = project_config.get_holdouts_for_rule(rule['id'])
@@ -467,7 +476,16 @@ module Optimizely
       return [nil, variation, skip_to_everyone_else, reasons] if variation
 
       # Step 2: Global holdout check
-      return [global_holdout_decision, nil, skip_to_everyone_else, reasons] if global_holdout_decision && rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
+      if global_holdout_decision
+        if rule['type'] != Helpers::Constants::EXPERIMENT_TYPES['td']
+          return [global_holdout_decision, nil, skip_to_everyone_else, reasons]
+        else
+          holdout_key = global_holdout_decision.experiment ? global_holdout_decision.experiment['key'] : 'unknown'
+          message = "Holdout '#{holdout_key}' has excludeTargetedDeliveries enabled, continuing to rollout evaluation."
+          @logger.log(Logger::INFO, message)
+          reasons.push(message)
+        end
+      end
 
       # Step 3: Local holdout check
       local_holdouts = project_config.get_holdouts_for_rule(rule['id'])

--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#    Copyright 2016-2020, 2022, Optimizely and contributors
+#    Copyright 2016-2020, 2022, 2026, Optimizely and contributors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -349,6 +349,9 @@ module Optimizely
                 },
                 'includedRules' => {
                   'type' => %w[array null]
+                },
+                'excludeTargetedDeliveries' => {
+                  'type' => 'boolean'
                 }
               }
             }
@@ -369,6 +372,9 @@ module Optimizely
                 },
                 'includedRules' => {
                   'type' => %w[array null]
+                },
+                'excludeTargetedDeliveries' => {
+                  'type' => 'boolean'
                 }
               }
             }

--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -350,7 +350,7 @@ module Optimizely
                 'includedRules' => {
                   'type' => %w[array null]
                 },
-                'excludeTargetedDeliveries' => {
+                'exclude_targeted_deliveries' => {
                   'type' => 'boolean'
                 }
               }
@@ -373,7 +373,7 @@ module Optimizely
                 'includedRules' => {
                   'type' => %w[array null]
                 },
-                'excludeTargetedDeliveries' => {
+                'exclude_targeted_deliveries' => {
                   'type' => 'boolean'
                 }
               }

--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -350,7 +350,7 @@ module Optimizely
                 'includedRules' => {
                   'type' => %w[array null]
                 },
-                'exclude_targeted_deliveries' => {
+                'excludeTargetedDeliveries' => {
                   'type' => 'boolean'
                 }
               }
@@ -373,7 +373,7 @@ module Optimizely
                 'includedRules' => {
                   'type' => %w[array null]
                 },
-                'exclude_targeted_deliveries' => {
+                'excludeTargetedDeliveries' => {
                   'type' => 'boolean'
                 }
               }

--- a/lib/optimizely/helpers/constants.rb
+++ b/lib/optimizely/helpers/constants.rb
@@ -372,9 +372,6 @@ module Optimizely
                 },
                 'includedRules' => {
                   'type' => %w[array null]
-                },
-                'excludeTargetedDeliveries' => {
-                  'type' => 'boolean'
                 }
               }
             }

--- a/spec/decision_service_holdout_spec.rb
+++ b/spec/decision_service_holdout_spec.rb
@@ -1207,7 +1207,7 @@ describe Optimizely::DecisionService do
     end
 
     describe 'local holdout with excludeTargetedDeliveries' do
-      it 'skips local holdout for TD rules when excludeTargetedDeliveries is true' do
+      it 'local holdout still applies to TD rules even when excludeTargetedDeliveries is true' do
         local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
         local_holdout['excludeTargetedDeliveries'] = true
 
@@ -1222,10 +1222,21 @@ describe Optimizely::DecisionService do
             .and_return(Optimizely::DecisionService::DecisionResult.new(nil, false, []))
         end
 
-        # Mock get_variation to simulate rule match
-        allow(ds).to receive(:get_variation).and_return(
-          Optimizely::DecisionService::VariationResult.new(nil, false, ['Bucketed into TD rule'], '122228')
-        )
+        # Local holdout fires
+        allow(ds).to receive(:get_variation_for_holdout)
+          .with(local_holdout, anything, anything)
+          .and_return(
+            Optimizely::DecisionService::DecisionResult.new(
+              Optimizely::DecisionService::Decision.new(
+                local_holdout,
+                local_holdout['variations'].first,
+                Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'],
+                nil
+              ),
+              false,
+              ['User in local holdout']
+            )
+          )
 
         user_ctx = project_with_holdouts.create_user_context('test_user', {})
         user_profile_tracker = Optimizely::UserProfileTracker.new('test_user', nil, spy_logger)
@@ -1238,9 +1249,10 @@ describe Optimizely::DecisionService do
           user_profile_tracker
         )
 
-        # Local holdout should be skipped for TD rule; regular evaluation proceeds
-        expect(result.variation_id).to eq('122228')
-        expect(result.holdout_decision).to be_nil
+        # Local holdout MUST still apply — excludeTargetedDeliveries is ignored for local holdouts
+        expect(result.holdout_decision).not_to be_nil
+        expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
+        expect(result.variation_id).to eq(local_holdout['variations'].first['id'])
       end
 
       it 'applies local holdout for AB rules even when excludeTargetedDeliveries is true' do
@@ -1333,6 +1345,105 @@ describe Optimizely::DecisionService do
         )
 
         # Holdout applies to TD rule because excludeTargetedDeliveries is false
+        expect(result.holdout_decision).not_to be_nil
+        expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
+      end
+    end
+
+    describe 'global holdout excludeTargetedDeliveries integration with get_decision_for_flag' do
+      it 'returns TD decision with holdout_decision attached when excludeTargetedDeliveries=true and TD succeeds' do
+        global_holdout = config_with_holdouts.get_holdout('holdout_1')
+        global_holdout['excludeTargetedDeliveries'] = true
+
+        holdout_variation = global_holdout['variations'].first
+        holdout_dec = Optimizely::DecisionService::Decision.new(
+          global_holdout,
+          holdout_variation,
+          Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'],
+          nil
+        )
+
+        # Global holdout hits
+        allow(ds).to receive(:get_variation_for_holdout)
+          .with(global_holdout, anything, anything)
+          .and_return(Optimizely::DecisionService::DecisionResult.new(holdout_dec, false, ['User in holdout']))
+
+        # Other global holdouts miss
+        config_with_holdouts.global_holdouts.reject { |h| h['id'] == 'holdout_1' }.each do |h|
+          allow(ds).to receive(:get_variation_for_holdout)
+            .with(h, anything, anything)
+            .and_return(Optimizely::DecisionService::DecisionResult.new(nil, false, []))
+        end
+
+        # Set experiment 122227 as TD and mock a successful TD match
+        experiment = config_with_holdouts.experiment_id_map['122227']
+        experiment['type'] = 'td'
+
+        td_decision = Optimizely::DecisionService::Decision.new(
+          experiment,
+          experiment['variations'].first,
+          Optimizely::DecisionService::DECISION_SOURCES['FEATURE_TEST'],
+          nil
+        )
+
+        allow(ds).to receive(:get_variation_for_feature_experiment).and_return(
+          Optimizely::DecisionService::DecisionResult.new(td_decision, false, ['TD matched'])
+        )
+
+        feature_flag = config_with_holdouts.feature_flag_key_map['boolean_feature']
+        user_ctx = project_with_holdouts.create_user_context('test_user', {})
+
+        result = ds.get_decision_for_flag(feature_flag, user_ctx, config_with_holdouts)
+
+        # TD decision is returned as the primary decision
+        expect(result.decision).not_to be_nil
+        expect(result.decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['FEATURE_TEST'])
+
+        # holdout_decision is attached separately for impression event
+        expect(result.holdout_decision).not_to be_nil
+        expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
+      end
+
+      it 'returns nil decision with holdout_decision attached when excludeTargetedDeliveries=true and TD returns nil' do
+        global_holdout = config_with_holdouts.get_holdout('holdout_1')
+        global_holdout['excludeTargetedDeliveries'] = true
+
+        holdout_variation = global_holdout['variations'].first
+        holdout_dec = Optimizely::DecisionService::Decision.new(
+          global_holdout,
+          holdout_variation,
+          Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'],
+          nil
+        )
+
+        # Global holdout hits
+        allow(ds).to receive(:get_variation_for_holdout)
+          .with(global_holdout, anything, anything)
+          .and_return(Optimizely::DecisionService::DecisionResult.new(holdout_dec, false, ['User in holdout']))
+
+        config_with_holdouts.global_holdouts.reject { |h| h['id'] == 'holdout_1' }.each do |h|
+          allow(ds).to receive(:get_variation_for_holdout)
+            .with(h, anything, anything)
+            .and_return(Optimizely::DecisionService::DecisionResult.new(nil, false, []))
+        end
+
+        # Experiment and rollout both return nil
+        allow(ds).to receive(:get_variation_for_feature_experiment).and_return(
+          Optimizely::DecisionService::DecisionResult.new(nil, false, ['No experiment match'])
+        )
+        allow(ds).to receive(:get_variation_for_feature_rollout).and_return(
+          Optimizely::DecisionService::DecisionResult.new(nil, false, ['No rollout match'])
+        )
+
+        feature_flag = config_with_holdouts.feature_flag_key_map['boolean_feature']
+        user_ctx = project_with_holdouts.create_user_context('test_user', {})
+
+        result = ds.get_decision_for_flag(feature_flag, user_ctx, config_with_holdouts)
+
+        # Decision is nil — does NOT fall back to holdout as the primary decision
+        expect(result.decision).to be_nil
+
+        # But holdout_decision is still attached for impression event
         expect(result.holdout_decision).not_to be_nil
         expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
       end

--- a/spec/decision_service_holdout_spec.rb
+++ b/spec/decision_service_holdout_spec.rb
@@ -1035,7 +1035,7 @@ describe Optimizely::DecisionService do
     end
   end
 
-  describe 'exclude_targeted_deliveries holdout behavior' do
+  describe 'excludeTargetedDeliveries holdout behavior' do
     let(:config_with_holdouts) do
       Optimizely::DatafileProjectConfig.new(
         OptimizelySpec::CONFIG_BODY_WITH_HOLDOUTS_JSON,
@@ -1058,10 +1058,10 @@ describe Optimizely::DecisionService do
 
     after(:example) { project_with_holdouts&.close }
 
-    describe 'global holdout with exclude_targeted_deliveries' do
-      it 'applies holdout normally when exclude_targeted_deliveries is false' do
+    describe 'global holdout with excludeTargetedDeliveries' do
+      it 'applies holdout normally when excludeTargetedDeliveries is false' do
         global_holdout = config_with_holdouts.get_holdout('holdout_1')
-        global_holdout['exclude_targeted_deliveries'] = false
+        global_holdout['excludeTargetedDeliveries'] = false
 
         allow(ds).to receive(:get_variation_for_holdout)
           .with(global_holdout, anything, anything)
@@ -1125,10 +1125,10 @@ describe Optimizely::DecisionService do
       end
     end
 
-    describe 'global holdout with missing exclude_targeted_deliveries (backward compat)' do
+    describe 'global holdout with missing excludeTargetedDeliveries (backward compat)' do
       it 'defaults to applying holdout normally when field is absent' do
         global_holdout = config_with_holdouts.get_holdout('holdout_1')
-        global_holdout.delete('exclude_targeted_deliveries')
+        global_holdout.delete('excludeTargetedDeliveries')
 
         allow(ds).to receive(:get_variation_for_holdout)
           .with(global_holdout, anything, anything)
@@ -1162,10 +1162,10 @@ describe Optimizely::DecisionService do
       end
     end
 
-    describe 'local holdout with exclude_targeted_deliveries' do
-      it 'local holdout still applies even when exclude_targeted_deliveries is true' do
+    describe 'local holdout with excludeTargetedDeliveries' do
+      it 'local holdout still applies even when excludeTargetedDeliveries is true' do
         local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
-        local_holdout['exclude_targeted_deliveries'] = true
+        local_holdout['excludeTargetedDeliveries'] = true
 
         experiment = config_with_holdouts.experiment_id_map['122227']
 
@@ -1203,15 +1203,15 @@ describe Optimizely::DecisionService do
           user_profile_tracker
         )
 
-        # Local holdout MUST still apply — exclude_targeted_deliveries is ignored for local holdouts
+        # Local holdout MUST still apply — excludeTargetedDeliveries is ignored for local holdouts
         expect(result.holdout_decision).not_to be_nil
         expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
         expect(result.variation_id).to eq(local_holdout['variations'].first['id'])
       end
 
-      it 'applies local holdout for all rules even when exclude_targeted_deliveries is true' do
+      it 'applies local holdout for all rules even when excludeTargetedDeliveries is true' do
         local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
-        local_holdout['exclude_targeted_deliveries'] = true
+        local_holdout['excludeTargetedDeliveries'] = true
 
         experiment = config_with_holdouts.experiment_id_map['122227']
 
@@ -1254,9 +1254,9 @@ describe Optimizely::DecisionService do
         expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
       end
 
-      it 'applies local holdout normally when exclude_targeted_deliveries is false' do
+      it 'applies local holdout normally when excludeTargetedDeliveries is false' do
         local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
-        local_holdout['exclude_targeted_deliveries'] = false
+        local_holdout['excludeTargetedDeliveries'] = false
 
         experiment = config_with_holdouts.experiment_id_map['122227']
 
@@ -1267,7 +1267,7 @@ describe Optimizely::DecisionService do
             .and_return(Optimizely::DecisionService::DecisionResult.new(nil, false, []))
         end
 
-        # Local holdout fires even for TD rule because exclude_targeted_deliveries is false
+        # Local holdout fires even for TD rule because excludeTargetedDeliveries is false
         allow(ds).to receive(:get_variation_for_holdout)
           .with(local_holdout, anything, anything)
           .and_return(
@@ -1294,16 +1294,16 @@ describe Optimizely::DecisionService do
           user_profile_tracker
         )
 
-        # Holdout applies to TD rule because exclude_targeted_deliveries is false
+        # Holdout applies to TD rule because excludeTargetedDeliveries is false
         expect(result.holdout_decision).not_to be_nil
         expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
       end
     end
 
-    describe 'global holdout exclude_targeted_deliveries integration with get_decision_for_flag' do
-      it 'skips experiments and returns rollout decision with holdout_decision attached when exclude_targeted_deliveries=true' do
+    describe 'global holdout excludeTargetedDeliveries integration with get_decision_for_flag' do
+      it 'skips experiments and returns rollout decision with holdout_decision attached when excludeTargetedDeliveries=true' do
         global_holdout = config_with_holdouts.get_holdout('holdout_1')
-        global_holdout['exclude_targeted_deliveries'] = true
+        global_holdout['excludeTargetedDeliveries'] = true
 
         holdout_variation = global_holdout['variations'].first
         holdout_dec = Optimizely::DecisionService::Decision.new(
@@ -1339,9 +1339,9 @@ describe Optimizely::DecisionService do
         expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
       end
 
-      it 'returns nil decision with holdout_decision attached when exclude_targeted_deliveries=true and TD returns nil' do
+      it 'returns nil decision with holdout_decision attached when excludeTargetedDeliveries=true and TD returns nil' do
         global_holdout = config_with_holdouts.get_holdout('holdout_1')
-        global_holdout['exclude_targeted_deliveries'] = true
+        global_holdout['excludeTargetedDeliveries'] = true
 
         holdout_variation = global_holdout['variations'].first
         holdout_dec = Optimizely::DecisionService::Decision.new(
@@ -1384,10 +1384,10 @@ describe Optimizely::DecisionService do
       end
     end
 
-    describe 'forced decision beats holdout with exclude_targeted_deliveries' do
-      it 'returns forced decision even when exclude_targeted_deliveries is true and holdout covers the rule' do
+    describe 'forced decision beats holdout with excludeTargetedDeliveries' do
+      it 'returns forced decision even when excludeTargetedDeliveries is true and holdout covers the rule' do
         local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
-        local_holdout['exclude_targeted_deliveries'] = true
+        local_holdout['excludeTargetedDeliveries'] = true
         expect(local_holdout['trafficAllocation'].first['endOfRange']).to eq(10_000)
 
         experiment = config_with_holdouts.experiment_id_map['122227']

--- a/spec/decision_service_holdout_spec.rb
+++ b/spec/decision_service_holdout_spec.rb
@@ -1033,4 +1033,341 @@ describe Optimizely::DecisionService do
       end
     end
   end
+
+  describe 'excludeTargetedDeliveries holdout behavior' do
+    let(:config_with_holdouts) do
+      Optimizely::DatafileProjectConfig.new(
+        OptimizelySpec::CONFIG_BODY_WITH_HOLDOUTS_JSON,
+        spy_logger,
+        error_handler
+      )
+    end
+
+    let(:project_with_holdouts) do
+      Optimizely::Project.new(
+        datafile: OptimizelySpec::CONFIG_BODY_WITH_HOLDOUTS_JSON,
+        logger: spy_logger,
+        error_handler: error_handler
+      )
+    end
+
+    let(:ds) do
+      Optimizely::DecisionService.new(spy_logger, spy_cmab_service)
+    end
+
+    after(:example) { project_with_holdouts&.close }
+
+    describe 'global holdout with excludeTargetedDeliveries' do
+      it 'applies holdout normally when excludeTargetedDeliveries is false' do
+        global_holdout = config_with_holdouts.get_holdout('holdout_1')
+        global_holdout['excludeTargetedDeliveries'] = false
+
+        allow(ds).to receive(:get_variation_for_holdout)
+          .with(global_holdout, anything, anything)
+          .and_return(
+            Optimizely::DecisionService::DecisionResult.new(
+              Optimizely::DecisionService::Decision.new(
+                global_holdout,
+                global_holdout['variations'].first,
+                Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'],
+                nil
+              ),
+              false,
+              ['User in global holdout']
+            )
+          )
+
+        # Stub other global holdouts to miss
+        config_with_holdouts.global_holdouts.reject { |h| h['id'] == 'holdout_1' }.each do |h|
+          allow(ds).to receive(:get_variation_for_holdout)
+            .with(h, anything, anything)
+            .and_return(Optimizely::DecisionService::DecisionResult.new(nil, false, []))
+        end
+
+        feature_flag = config_with_holdouts.feature_flag_key_map['boolean_feature']
+        user_ctx = project_with_holdouts.create_user_context('test_user', {})
+
+        result = ds.get_decision_for_flag(feature_flag, user_ctx, config_with_holdouts)
+
+        expect(result.decision).not_to be_nil
+        expect(result.decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
+      end
+
+      it 'stores holdout decision but lets TD rules bypass when excludeTargetedDeliveries is true' do
+        global_holdout = config_with_holdouts.get_holdout('holdout_1')
+
+        holdout_decision = Optimizely::DecisionService::Decision.new(
+          global_holdout,
+          global_holdout['variations'].first,
+          Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'],
+          nil
+        )
+
+        # Set experiment 122227 as a TD rule
+        experiment = config_with_holdouts.experiment_id_map['122227']
+        experiment['type'] = 'td'
+
+        # Stub local holdouts to miss so only global holdout logic is tested
+        allow(ds).to receive(:get_variation_for_holdout).and_return(
+          Optimizely::DecisionService::DecisionResult.new(nil, false, [])
+        )
+
+        # Mock get_variation to return a variation (simulating TD rule match)
+        allow(ds).to receive(:get_variation).and_return(
+          Optimizely::DecisionService::VariationResult.new(nil, false, ['Bucketed into TD'], '122228')
+        )
+
+        user_ctx = project_with_holdouts.create_user_context('test_user', {})
+        user_profile_tracker = Optimizely::UserProfileTracker.new('test_user', nil, spy_logger)
+
+        # Pass holdout_decision as global_holdout_decision — TD rule should bypass it
+        result = ds.get_variation_from_experiment_rule(
+          config_with_holdouts,
+          'boolean_feature',
+          experiment,
+          user_ctx,
+          user_profile_tracker,
+          [],
+          holdout_decision
+        )
+
+        # TD rule should NOT get holdout decision; should proceed to regular evaluation
+        expect(result.holdout_decision).to be_nil
+        expect(result.variation_id).to eq('122228')
+      end
+
+      it 'applies holdout to non-TD (AB) rules even when excludeTargetedDeliveries is true' do
+        global_holdout = config_with_holdouts.get_holdout('holdout_1')
+        global_holdout['excludeTargetedDeliveries'] = true
+
+        holdout_decision = Optimizely::DecisionService::Decision.new(
+          global_holdout,
+          global_holdout['variations'].first,
+          Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'],
+          nil
+        )
+
+        # Experiment 122227 as AB type (non-TD)
+        experiment = config_with_holdouts.experiment_id_map['122227']
+        experiment['type'] = 'ab'
+
+        user_ctx = project_with_holdouts.create_user_context('test_user', {})
+        user_profile_tracker = Optimizely::UserProfileTracker.new('test_user', nil, spy_logger)
+
+        result = ds.get_variation_from_experiment_rule(
+          config_with_holdouts,
+          'boolean_feature',
+          experiment,
+          user_ctx,
+          user_profile_tracker,
+          [],
+          holdout_decision
+        )
+
+        # AB rule should get holdout decision since it's not TD
+        expect(result.holdout_decision).to eq(holdout_decision)
+      end
+    end
+
+    describe 'global holdout with missing excludeTargetedDeliveries (backward compat)' do
+      it 'defaults to applying holdout normally when field is absent' do
+        global_holdout = config_with_holdouts.get_holdout('holdout_1')
+        global_holdout.delete('excludeTargetedDeliveries')
+
+        allow(ds).to receive(:get_variation_for_holdout)
+          .with(global_holdout, anything, anything)
+          .and_return(
+            Optimizely::DecisionService::DecisionResult.new(
+              Optimizely::DecisionService::Decision.new(
+                global_holdout,
+                global_holdout['variations'].first,
+                Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'],
+                nil
+              ),
+              false,
+              ['User in global holdout']
+            )
+          )
+
+        config_with_holdouts.global_holdouts.reject { |h| h['id'] == 'holdout_1' }.each do |h|
+          allow(ds).to receive(:get_variation_for_holdout)
+            .with(h, anything, anything)
+            .and_return(Optimizely::DecisionService::DecisionResult.new(nil, false, []))
+        end
+
+        feature_flag = config_with_holdouts.feature_flag_key_map['boolean_feature']
+        user_ctx = project_with_holdouts.create_user_context('test_user', {})
+
+        result = ds.get_decision_for_flag(feature_flag, user_ctx, config_with_holdouts)
+
+        # Missing field means false => holdout applies immediately
+        expect(result.decision).not_to be_nil
+        expect(result.decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
+      end
+    end
+
+    describe 'local holdout with excludeTargetedDeliveries' do
+      it 'skips local holdout for TD rules when excludeTargetedDeliveries is true' do
+        local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
+        local_holdout['excludeTargetedDeliveries'] = true
+
+        # Set experiment 122227 as TD type
+        experiment = config_with_holdouts.experiment_id_map['122227']
+        experiment['type'] = 'td'
+
+        # All global holdouts miss
+        config_with_holdouts.global_holdouts.each do |gh|
+          allow(ds).to receive(:get_variation_for_holdout)
+            .with(gh, anything, anything)
+            .and_return(Optimizely::DecisionService::DecisionResult.new(nil, false, []))
+        end
+
+        # Mock get_variation to simulate rule match
+        allow(ds).to receive(:get_variation).and_return(
+          Optimizely::DecisionService::VariationResult.new(nil, false, ['Bucketed into TD rule'], '122228')
+        )
+
+        user_ctx = project_with_holdouts.create_user_context('test_user', {})
+        user_profile_tracker = Optimizely::UserProfileTracker.new('test_user', nil, spy_logger)
+
+        result = ds.get_variation_from_experiment_rule(
+          config_with_holdouts,
+          'boolean_feature',
+          experiment,
+          user_ctx,
+          user_profile_tracker
+        )
+
+        # Local holdout should be skipped for TD rule; regular evaluation proceeds
+        expect(result.variation_id).to eq('122228')
+        expect(result.holdout_decision).to be_nil
+      end
+
+      it 'applies local holdout for AB rules even when excludeTargetedDeliveries is true' do
+        local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
+        local_holdout['excludeTargetedDeliveries'] = true
+
+        # Experiment 122227 as AB type
+        experiment = config_with_holdouts.experiment_id_map['122227']
+        experiment['type'] = 'ab'
+
+        # All global holdouts miss
+        config_with_holdouts.global_holdouts.each do |gh|
+          allow(ds).to receive(:get_variation_for_holdout)
+            .with(gh, anything, anything)
+            .and_return(Optimizely::DecisionService::DecisionResult.new(nil, false, []))
+        end
+
+        # Local holdout fires for AB rule
+        allow(ds).to receive(:get_variation_for_holdout)
+          .with(local_holdout, anything, anything)
+          .and_return(
+            Optimizely::DecisionService::DecisionResult.new(
+              Optimizely::DecisionService::Decision.new(
+                local_holdout,
+                local_holdout['variations'].first,
+                Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'],
+                nil
+              ),
+              false,
+              ['User in local holdout']
+            )
+          )
+
+        user_ctx = project_with_holdouts.create_user_context('test_user', {})
+        user_profile_tracker = Optimizely::UserProfileTracker.new('test_user', nil, spy_logger)
+
+        result = ds.get_variation_from_experiment_rule(
+          config_with_holdouts,
+          'boolean_feature',
+          experiment,
+          user_ctx,
+          user_profile_tracker
+        )
+
+        # Local holdout applies to AB rule
+        expect(result.holdout_decision).not_to be_nil
+        expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
+      end
+
+      it 'applies local holdout normally when excludeTargetedDeliveries is false' do
+        local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
+        local_holdout['excludeTargetedDeliveries'] = false
+
+        # Set experiment 122227 as TD type
+        experiment = config_with_holdouts.experiment_id_map['122227']
+        experiment['type'] = 'td'
+
+        # All global holdouts miss
+        config_with_holdouts.global_holdouts.each do |gh|
+          allow(ds).to receive(:get_variation_for_holdout)
+            .with(gh, anything, anything)
+            .and_return(Optimizely::DecisionService::DecisionResult.new(nil, false, []))
+        end
+
+        # Local holdout fires even for TD rule because excludeTargetedDeliveries is false
+        allow(ds).to receive(:get_variation_for_holdout)
+          .with(local_holdout, anything, anything)
+          .and_return(
+            Optimizely::DecisionService::DecisionResult.new(
+              Optimizely::DecisionService::Decision.new(
+                local_holdout,
+                local_holdout['variations'].first,
+                Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'],
+                nil
+              ),
+              false,
+              ['User in local holdout']
+            )
+          )
+
+        user_ctx = project_with_holdouts.create_user_context('test_user', {})
+        user_profile_tracker = Optimizely::UserProfileTracker.new('test_user', nil, spy_logger)
+
+        result = ds.get_variation_from_experiment_rule(
+          config_with_holdouts,
+          'boolean_feature',
+          experiment,
+          user_ctx,
+          user_profile_tracker
+        )
+
+        # Holdout applies to TD rule because excludeTargetedDeliveries is false
+        expect(result.holdout_decision).not_to be_nil
+        expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
+      end
+    end
+
+    describe 'forced decision beats holdout with excludeTargetedDeliveries' do
+      it 'returns forced decision even when excludeTargetedDeliveries is true and holdout covers the rule' do
+        local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
+        local_holdout['excludeTargetedDeliveries'] = true
+        expect(local_holdout['trafficAllocation'].first['endOfRange']).to eq(10_000)
+
+        experiment = config_with_holdouts.experiment_id_map['122227']
+        experiment['type'] = 'ab'
+
+        user_ctx = project_with_holdouts.create_user_context('test_user', {})
+        context = Optimizely::OptimizelyUserContext::OptimizelyDecisionContext.new(
+          'boolean_feature',
+          'test_experiment_with_audience'
+        )
+        forced = Optimizely::OptimizelyUserContext::OptimizelyForcedDecision.new('control_with_audience')
+        user_ctx.set_forced_decision(context, forced)
+
+        user_profile_tracker = Optimizely::UserProfileTracker.new('test_user', nil, spy_logger)
+
+        result = ds.get_variation_from_experiment_rule(
+          config_with_holdouts,
+          'boolean_feature',
+          experiment,
+          user_ctx,
+          user_profile_tracker
+        )
+
+        expect(result.variation_id).to eq('122228')
+        expect(result.holdout_decision).to be_nil
+      end
+    end
+  end
 end

--- a/spec/decision_service_holdout_spec.rb
+++ b/spec/decision_service_holdout_spec.rb
@@ -1094,35 +1094,6 @@ describe Optimizely::DecisionService do
         expect(result.decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
       end
 
-      it 'blocks all experiment rules when global_holdout_decision is set (regardless of type)' do
-        global_holdout = config_with_holdouts.get_holdout('holdout_1')
-
-        holdout_decision = Optimizely::DecisionService::Decision.new(
-          global_holdout,
-          global_holdout['variations'].first,
-          Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'],
-          nil
-        )
-
-        experiment = config_with_holdouts.experiment_id_map['122227']
-
-        user_ctx = project_with_holdouts.create_user_context('test_user', {})
-        user_profile_tracker = Optimizely::UserProfileTracker.new('test_user', nil, spy_logger)
-
-        result = ds.get_variation_from_experiment_rule(
-          config_with_holdouts,
-          'boolean_feature',
-          experiment,
-          user_ctx,
-          user_profile_tracker,
-          [],
-          holdout_decision
-        )
-
-        # All experiment rules should be blocked — holdout decision returned
-        expect(result.holdout_decision).to eq(holdout_decision)
-        expect(result.variation_id).to be_nil
-      end
     end
 
     describe 'global holdout with missing excludeTargetedDeliveries (backward compat)' do

--- a/spec/decision_service_holdout_spec.rb
+++ b/spec/decision_service_holdout_spec.rb
@@ -1035,7 +1035,7 @@ describe Optimizely::DecisionService do
     end
   end
 
-  describe 'excludeTargetedDeliveries holdout behavior' do
+  describe 'exclude_targeted_deliveries holdout behavior' do
     let(:config_with_holdouts) do
       Optimizely::DatafileProjectConfig.new(
         OptimizelySpec::CONFIG_BODY_WITH_HOLDOUTS_JSON,
@@ -1058,10 +1058,10 @@ describe Optimizely::DecisionService do
 
     after(:example) { project_with_holdouts&.close }
 
-    describe 'global holdout with excludeTargetedDeliveries' do
-      it 'applies holdout normally when excludeTargetedDeliveries is false' do
+    describe 'global holdout with exclude_targeted_deliveries' do
+      it 'applies holdout normally when exclude_targeted_deliveries is false' do
         global_holdout = config_with_holdouts.get_holdout('holdout_1')
-        global_holdout['excludeTargetedDeliveries'] = false
+        global_holdout['exclude_targeted_deliveries'] = false
 
         allow(ds).to receive(:get_variation_for_holdout)
           .with(global_holdout, anything, anything)
@@ -1094,7 +1094,7 @@ describe Optimizely::DecisionService do
         expect(result.decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
       end
 
-      it 'stores holdout decision but lets TD rules bypass when excludeTargetedDeliveries is true' do
+      it 'stores holdout decision but lets TD rules bypass when exclude_targeted_deliveries is true' do
         global_holdout = config_with_holdouts.get_holdout('holdout_1')
 
         holdout_decision = Optimizely::DecisionService::Decision.new(
@@ -1138,9 +1138,9 @@ describe Optimizely::DecisionService do
         expect(result.reasons).to include(a_string_matching(/Holdout 'global_holdout' has excludeTargetedDeliveries enabled, continuing to rollout evaluation/))
       end
 
-      it 'applies holdout to non-TD (AB) rules even when excludeTargetedDeliveries is true' do
+      it 'applies holdout to non-TD (AB) rules even when exclude_targeted_deliveries is true' do
         global_holdout = config_with_holdouts.get_holdout('holdout_1')
-        global_holdout['excludeTargetedDeliveries'] = true
+        global_holdout['exclude_targeted_deliveries'] = true
 
         holdout_decision = Optimizely::DecisionService::Decision.new(
           global_holdout,
@@ -1171,10 +1171,10 @@ describe Optimizely::DecisionService do
       end
     end
 
-    describe 'global holdout with missing excludeTargetedDeliveries (backward compat)' do
+    describe 'global holdout with missing exclude_targeted_deliveries (backward compat)' do
       it 'defaults to applying holdout normally when field is absent' do
         global_holdout = config_with_holdouts.get_holdout('holdout_1')
-        global_holdout.delete('excludeTargetedDeliveries')
+        global_holdout.delete('exclude_targeted_deliveries')
 
         allow(ds).to receive(:get_variation_for_holdout)
           .with(global_holdout, anything, anything)
@@ -1208,10 +1208,10 @@ describe Optimizely::DecisionService do
       end
     end
 
-    describe 'local holdout with excludeTargetedDeliveries' do
-      it 'local holdout still applies to TD rules even when excludeTargetedDeliveries is true' do
+    describe 'local holdout with exclude_targeted_deliveries' do
+      it 'local holdout still applies to TD rules even when exclude_targeted_deliveries is true' do
         local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
-        local_holdout['excludeTargetedDeliveries'] = true
+        local_holdout['exclude_targeted_deliveries'] = true
 
         # Set experiment 122227 as TD type
         experiment = config_with_holdouts.experiment_id_map['122227']
@@ -1251,15 +1251,15 @@ describe Optimizely::DecisionService do
           user_profile_tracker
         )
 
-        # Local holdout MUST still apply — excludeTargetedDeliveries is ignored for local holdouts
+        # Local holdout MUST still apply — exclude_targeted_deliveries is ignored for local holdouts
         expect(result.holdout_decision).not_to be_nil
         expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
         expect(result.variation_id).to eq(local_holdout['variations'].first['id'])
       end
 
-      it 'applies local holdout for AB rules even when excludeTargetedDeliveries is true' do
+      it 'applies local holdout for AB rules even when exclude_targeted_deliveries is true' do
         local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
-        local_holdout['excludeTargetedDeliveries'] = true
+        local_holdout['exclude_targeted_deliveries'] = true
 
         # Experiment 122227 as AB type
         experiment = config_with_holdouts.experiment_id_map['122227']
@@ -1304,9 +1304,9 @@ describe Optimizely::DecisionService do
         expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
       end
 
-      it 'applies local holdout normally when excludeTargetedDeliveries is false' do
+      it 'applies local holdout normally when exclude_targeted_deliveries is false' do
         local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
-        local_holdout['excludeTargetedDeliveries'] = false
+        local_holdout['exclude_targeted_deliveries'] = false
 
         # Set experiment 122227 as TD type
         experiment = config_with_holdouts.experiment_id_map['122227']
@@ -1319,7 +1319,7 @@ describe Optimizely::DecisionService do
             .and_return(Optimizely::DecisionService::DecisionResult.new(nil, false, []))
         end
 
-        # Local holdout fires even for TD rule because excludeTargetedDeliveries is false
+        # Local holdout fires even for TD rule because exclude_targeted_deliveries is false
         allow(ds).to receive(:get_variation_for_holdout)
           .with(local_holdout, anything, anything)
           .and_return(
@@ -1346,16 +1346,16 @@ describe Optimizely::DecisionService do
           user_profile_tracker
         )
 
-        # Holdout applies to TD rule because excludeTargetedDeliveries is false
+        # Holdout applies to TD rule because exclude_targeted_deliveries is false
         expect(result.holdout_decision).not_to be_nil
         expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
       end
     end
 
-    describe 'global holdout excludeTargetedDeliveries integration with get_decision_for_flag' do
-      it 'returns TD decision with holdout_decision attached when excludeTargetedDeliveries=true and TD succeeds' do
+    describe 'global holdout exclude_targeted_deliveries integration with get_decision_for_flag' do
+      it 'returns TD decision with holdout_decision attached when exclude_targeted_deliveries=true and TD succeeds' do
         global_holdout = config_with_holdouts.get_holdout('holdout_1')
-        global_holdout['excludeTargetedDeliveries'] = true
+        global_holdout['exclude_targeted_deliveries'] = true
 
         holdout_variation = global_holdout['variations'].first
         holdout_dec = Optimizely::DecisionService::Decision.new(
@@ -1406,9 +1406,9 @@ describe Optimizely::DecisionService do
         expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
       end
 
-      it 'returns nil decision with holdout_decision attached when excludeTargetedDeliveries=true and TD returns nil' do
+      it 'returns nil decision with holdout_decision attached when exclude_targeted_deliveries=true and TD returns nil' do
         global_holdout = config_with_holdouts.get_holdout('holdout_1')
-        global_holdout['excludeTargetedDeliveries'] = true
+        global_holdout['exclude_targeted_deliveries'] = true
 
         holdout_variation = global_holdout['variations'].first
         holdout_dec = Optimizely::DecisionService::Decision.new(
@@ -1451,10 +1451,10 @@ describe Optimizely::DecisionService do
       end
     end
 
-    describe 'forced decision beats holdout with excludeTargetedDeliveries' do
-      it 'returns forced decision even when excludeTargetedDeliveries is true and holdout covers the rule' do
+    describe 'forced decision beats holdout with exclude_targeted_deliveries' do
+      it 'returns forced decision even when exclude_targeted_deliveries is true and holdout covers the rule' do
         local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
-        local_holdout['excludeTargetedDeliveries'] = true
+        local_holdout['exclude_targeted_deliveries'] = true
         expect(local_holdout['trafficAllocation'].first['endOfRange']).to eq(10_000)
 
         experiment = config_with_holdouts.experiment_id_map['122227']

--- a/spec/decision_service_holdout_spec.rb
+++ b/spec/decision_service_holdout_spec.rb
@@ -745,6 +745,7 @@ describe Optimizely::DecisionService do
         expect(notification).to have_key(:variables), 'Notification should contain variables'
         expect(notification).to have_key(:reasons), 'Notification should contain reasons'
         expect(notification).to have_key(:decision_event_dispatched), 'Notification should contain decision_event_dispatched'
+        expect(notification[:decision_event_dispatched]).to eq(true), 'decision_event_dispatched should be true when holdout impression is sent'
       end
     end
   end
@@ -1134,6 +1135,7 @@ describe Optimizely::DecisionService do
         # TD rule should NOT get holdout decision; should proceed to regular evaluation
         expect(result.holdout_decision).to be_nil
         expect(result.variation_id).to eq('122228')
+        expect(result.reasons).to include(a_string_matching(/Holdout 'global_holdout' has excludeTargetedDeliveries enabled, continuing to rollout evaluation/))
       end
 
       it 'applies holdout to non-TD (AB) rules even when excludeTargetedDeliveries is true' do

--- a/spec/decision_service_holdout_spec.rb
+++ b/spec/decision_service_holdout_spec.rb
@@ -1093,7 +1093,6 @@ describe Optimizely::DecisionService do
         expect(result.decision).not_to be_nil
         expect(result.decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
       end
-
     end
 
     describe 'global holdout with missing excludeTargetedDeliveries (backward compat)' do

--- a/spec/decision_service_holdout_spec.rb
+++ b/spec/decision_service_holdout_spec.rb
@@ -1094,7 +1094,7 @@ describe Optimizely::DecisionService do
         expect(result.decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
       end
 
-      it 'stores holdout decision but lets TD rules bypass when exclude_targeted_deliveries is true' do
+      it 'blocks all experiment rules when global_holdout_decision is set (regardless of type)' do
         global_holdout = config_with_holdouts.get_holdout('holdout_1')
 
         holdout_decision = Optimizely::DecisionService::Decision.new(
@@ -1104,54 +1104,7 @@ describe Optimizely::DecisionService do
           nil
         )
 
-        # Set experiment 122227 as a TD rule
         experiment = config_with_holdouts.experiment_id_map['122227']
-        experiment['type'] = 'td'
-
-        # Stub local holdouts to miss so only global holdout logic is tested
-        allow(ds).to receive(:get_variation_for_holdout).and_return(
-          Optimizely::DecisionService::DecisionResult.new(nil, false, [])
-        )
-
-        # Mock get_variation to return a variation (simulating TD rule match)
-        allow(ds).to receive(:get_variation).and_return(
-          Optimizely::DecisionService::VariationResult.new(nil, false, ['Bucketed into TD'], '122228')
-        )
-
-        user_ctx = project_with_holdouts.create_user_context('test_user', {})
-        user_profile_tracker = Optimizely::UserProfileTracker.new('test_user', nil, spy_logger)
-
-        # Pass holdout_decision as global_holdout_decision — TD rule should bypass it
-        result = ds.get_variation_from_experiment_rule(
-          config_with_holdouts,
-          'boolean_feature',
-          experiment,
-          user_ctx,
-          user_profile_tracker,
-          [],
-          holdout_decision
-        )
-
-        # TD rule should NOT get holdout decision; should proceed to regular evaluation
-        expect(result.holdout_decision).to be_nil
-        expect(result.variation_id).to eq('122228')
-        expect(result.reasons).to include(a_string_matching(/Holdout 'global_holdout' has excludeTargetedDeliveries enabled, continuing to rollout evaluation/))
-      end
-
-      it 'applies holdout to non-TD (AB) rules even when exclude_targeted_deliveries is true' do
-        global_holdout = config_with_holdouts.get_holdout('holdout_1')
-        global_holdout['exclude_targeted_deliveries'] = true
-
-        holdout_decision = Optimizely::DecisionService::Decision.new(
-          global_holdout,
-          global_holdout['variations'].first,
-          Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'],
-          nil
-        )
-
-        # Experiment 122227 as AB type (non-TD)
-        experiment = config_with_holdouts.experiment_id_map['122227']
-        experiment['type'] = 'ab'
 
         user_ctx = project_with_holdouts.create_user_context('test_user', {})
         user_profile_tracker = Optimizely::UserProfileTracker.new('test_user', nil, spy_logger)
@@ -1166,8 +1119,9 @@ describe Optimizely::DecisionService do
           holdout_decision
         )
 
-        # AB rule should get holdout decision since it's not TD
+        # All experiment rules should be blocked — holdout decision returned
         expect(result.holdout_decision).to eq(holdout_decision)
+        expect(result.variation_id).to be_nil
       end
     end
 
@@ -1209,13 +1163,11 @@ describe Optimizely::DecisionService do
     end
 
     describe 'local holdout with exclude_targeted_deliveries' do
-      it 'local holdout still applies to TD rules even when exclude_targeted_deliveries is true' do
+      it 'local holdout still applies even when exclude_targeted_deliveries is true' do
         local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
         local_holdout['exclude_targeted_deliveries'] = true
 
-        # Set experiment 122227 as TD type
         experiment = config_with_holdouts.experiment_id_map['122227']
-        experiment['type'] = 'td'
 
         # All global holdouts miss
         config_with_holdouts.global_holdouts.each do |gh|
@@ -1257,13 +1209,11 @@ describe Optimizely::DecisionService do
         expect(result.variation_id).to eq(local_holdout['variations'].first['id'])
       end
 
-      it 'applies local holdout for AB rules even when exclude_targeted_deliveries is true' do
+      it 'applies local holdout for all rules even when exclude_targeted_deliveries is true' do
         local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
         local_holdout['exclude_targeted_deliveries'] = true
 
-        # Experiment 122227 as AB type
         experiment = config_with_holdouts.experiment_id_map['122227']
-        experiment['type'] = 'ab'
 
         # All global holdouts miss
         config_with_holdouts.global_holdouts.each do |gh|
@@ -1299,7 +1249,7 @@ describe Optimizely::DecisionService do
           user_profile_tracker
         )
 
-        # Local holdout applies to AB rule
+        # Local holdout applies to all rules
         expect(result.holdout_decision).not_to be_nil
         expect(result.holdout_decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['HOLDOUT'])
       end
@@ -1308,9 +1258,7 @@ describe Optimizely::DecisionService do
         local_holdout = config_with_holdouts.get_holdout('holdout_local_1')
         local_holdout['exclude_targeted_deliveries'] = false
 
-        # Set experiment 122227 as TD type
         experiment = config_with_holdouts.experiment_id_map['122227']
-        experiment['type'] = 'td'
 
         # All global holdouts miss
         config_with_holdouts.global_holdouts.each do |gh|
@@ -1353,7 +1301,7 @@ describe Optimizely::DecisionService do
     end
 
     describe 'global holdout exclude_targeted_deliveries integration with get_decision_for_flag' do
-      it 'returns TD decision with holdout_decision attached when exclude_targeted_deliveries=true and TD succeeds' do
+      it 'skips experiments and returns rollout decision with holdout_decision attached when exclude_targeted_deliveries=true' do
         global_holdout = config_with_holdouts.get_holdout('holdout_1')
         global_holdout['exclude_targeted_deliveries'] = true
 
@@ -1377,29 +1325,14 @@ describe Optimizely::DecisionService do
             .and_return(Optimizely::DecisionService::DecisionResult.new(nil, false, []))
         end
 
-        # Set experiment 122227 as TD and mock a successful TD match
-        experiment = config_with_holdouts.experiment_id_map['122227']
-        experiment['type'] = 'td'
-
-        td_decision = Optimizely::DecisionService::Decision.new(
-          experiment,
-          experiment['variations'].first,
-          Optimizely::DecisionService::DECISION_SOURCES['FEATURE_TEST'],
-          nil
-        )
-
-        allow(ds).to receive(:get_variation_for_feature_experiment).and_return(
-          Optimizely::DecisionService::DecisionResult.new(td_decision, false, ['TD matched'])
-        )
-
-        feature_flag = config_with_holdouts.feature_flag_key_map['boolean_feature']
+        feature_flag = config_with_holdouts.feature_flag_key_map['boolean_single_variable_feature']
         user_ctx = project_with_holdouts.create_user_context('test_user', {})
 
         result = ds.get_decision_for_flag(feature_flag, user_ctx, config_with_holdouts)
 
-        # TD decision is returned as the primary decision
+        # Experiments are skipped; rollout decision is returned
         expect(result.decision).not_to be_nil
-        expect(result.decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['FEATURE_TEST'])
+        expect(result.decision.source).to eq(Optimizely::DecisionService::DECISION_SOURCES['ROLLOUT'])
 
         # holdout_decision is attached separately for impression event
         expect(result.holdout_decision).not_to be_nil


### PR DESCRIPTION
## Summary

Implements the `exclude_targeted_deliveries` field on Holdout objects. When enabled, users bucketed into a holdout are still served Targeted Delivery rules normally, while A/B Test and Multi-Armed Bandit rules continue to respect the holdout.

## Changes

- Added `exclude_targeted_deliveries` boolean to holdout and local holdout JSON schemas in constants
- Updated decision service to defer holdout decisions for Targeted Delivery rules when the flag is true
- Added unit tests covering all combinations of the flag with different rule types and backward compatibility

## Jira Ticket

[FSSDK-12735](https://optimizely-ext.atlassian.net/browse/FSSDK-12735)

[FSSDK-12735]: https://optimizely-ext.atlassian.net/browse/FSSDK-12735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ